### PR TITLE
Add `base_project` directory and update to Cairo 0.5.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+recursive-include src/nile/base_project/ *

--- a/src/nile/base_project/Makefile
+++ b/src/nile/base_project/Makefile
@@ -1,0 +1,3 @@
+# Build and test
+build :; nile compile
+test  :; pytest tests/

--- a/src/nile/base_project/contracts/contract.cairo
+++ b/src/nile/base_project/contracts/contract.cairo
@@ -24,7 +24,7 @@ end
 @view
 func get_balance{
         syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount : felt) -> (res : felt):
+        range_check_ptr}() -> (res : felt):
     let (res) = balance.read()
     return (res)
 end

--- a/src/nile/base_project/contracts/contract.cairo
+++ b/src/nile/base_project/contracts/contract.cairo
@@ -1,0 +1,30 @@
+# Declare this file as a StarkNet contract and set the required
+# builtins.
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+# Define a storage variable.
+@storage_var
+func balance() -> (res : felt):
+end
+
+# Increases the balance by the given amount.
+@external
+func increase_balance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(amount : felt):
+    let (res) = balance.read()
+    balance.write(res + amount)
+    return ()
+end
+
+# Returns the current balance.
+@view
+func get_balance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(amount : felt) -> (res : felt):
+    let (res) = balance.read()
+    return (res)
+end

--- a/src/nile/base_project/tests/test_contract.py
+++ b/src/nile/base_project/tests/test_contract.py
@@ -16,11 +16,14 @@ async def test_increase_balance():
     starknet = await Starknet.empty()
 
     # Deploy the contract.
-    contract = await starknet.deploy(CONTRACT_FILE)
+    contract = await starknet.deploy(
+        source=CONTRACT_FILE,
+    )
 
     # Invoke increase_balance() twice.
     await contract.increase_balance(amount=10).invoke()
     await contract.increase_balance(amount=20).invoke()
 
     # Check the result of get_balance().
-    assert await contract.get_balance().call() == (30,)
+    execution_info = await contract.get_balance().call()
+    assert execution_info.result == (30,)

--- a/src/nile/base_project/tests/test_contract.py
+++ b/src/nile/base_project/tests/test_contract.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+
+from starkware.starknet.testing.starknet import Starknet
+
+# The path to the contract source code.
+CONTRACT_FILE = os.path.join("contracts", "contract.cairo")
+
+
+# The testing library uses python's asyncio. So the following
+# decorator and the ``async`` keyword are needed.
+@pytest.mark.asyncio
+async def test_increase_balance():
+    # Create a new Starknet class that simulates the StarkNet
+    # system.
+    starknet = await Starknet.empty()
+
+    # Deploy the contract.
+    contract = await starknet.deploy(CONTRACT_FILE)
+
+    # Invoke increase_balance() twice.
+    await contract.increase_balance(amount=10).invoke()
+    await contract.increase_balance(amount=20).invoke()
+
+    # Check the result of get_balance().
+    assert await contract.get_balance().call() == (30,)

--- a/src/nile/base_project/tests/test_contract.py
+++ b/src/nile/base_project/tests/test_contract.py
@@ -1,6 +1,6 @@
+"""contract.cairo test file."""
 import os
 import pytest
-
 from starkware.starknet.testing.starknet import Starknet
 
 # The path to the contract source code.
@@ -11,6 +11,7 @@ CONTRACT_FILE = os.path.join("contracts", "contract.cairo")
 # decorator and the ``async`` keyword are needed.
 @pytest.mark.asyncio
 async def test_increase_balance():
+    """Test increase_balance method."""
     # Create a new Starknet class that simulates the StarkNet
     # system.
     starknet = await Starknet.empty()

--- a/src/nile/commands/init.py
+++ b/src/nile/commands/init.py
@@ -1,6 +1,7 @@
 """Command to kickstart a Nile project."""
+import os
 import subprocess
-import sys, os
+import sys
 from distutils.dir_util import copy_tree
 
 from nile.commands.install import install_command
@@ -25,7 +26,7 @@ def init_command():
 
     # create project directories
     print("🗄  Creating project directory tree")
-    copy_tree(os.path.join(os.path.dirname(__file__), "../base_project"), '.')
+    copy_tree(os.path.join(os.path.dirname(__file__), "../base_project"), ".")
 
     print("⛵️ Nile project ready! Try running:")
     print("")

--- a/src/nile/commands/init.py
+++ b/src/nile/commands/init.py
@@ -27,7 +27,7 @@ def init_command():
     # create project directories
     print("🗄  Creating project directory tree")
 
-    copy_tree(Path(__file__).parent / ".." / "base_project", ".")
+    copy_tree(Path(__file__).parent.parent / "base_project", ".")
 
     print("⛵️ Nile project ready! Try running:")
     print("")

--- a/src/nile/commands/init.py
+++ b/src/nile/commands/init.py
@@ -1,8 +1,8 @@
 """Command to kickstart a Nile project."""
-import os
 import subprocess
 import sys
 from distutils.dir_util import copy_tree
+from pathlib import Path
 
 from nile.commands.install import install_command
 
@@ -26,7 +26,8 @@ def init_command():
 
     # create project directories
     print("🗄  Creating project directory tree")
-    copy_tree(os.path.join(os.path.dirname(__file__), "../base_project"), ".")
+
+    copy_tree(Path(__file__).parent / ".." / "base_project", ".")
 
     print("⛵️ Nile project ready! Try running:")
     print("")

--- a/src/nile/commands/init.py
+++ b/src/nile/commands/init.py
@@ -1,7 +1,7 @@
 """Command to kickstart a Nile project."""
 import subprocess
-import sys
-from pathlib import Path
+import sys, os
+from distutils.dir_util import copy_tree
 
 from nile.commands.install import install_command
 
@@ -25,95 +25,9 @@ def init_command():
 
     # create project directories
     print("🗄  Creating project directory tree")
-    create_contracts()
-    create_tests()
-
-    with open("Makefile", "w") as fp:
-        fp.write(makefile)
+    copy_tree(os.path.join(os.path.dirname(__file__), "../base_project"), '.')
 
     print("⛵️ Nile project ready! Try running:")
     print("")
     print("nile compile")
     print("")
-
-
-def create_contracts():
-    """Create contracts/ directory."""
-    Path("contracts/").mkdir(parents=True, exist_ok=True)
-    with open("contracts/contract.cairo", "w") as fp:
-        fp.write(contract)
-
-
-def create_tests():
-    """Create tests/ directory."""
-    Path("tests/").mkdir(parents=True, exist_ok=True)
-    with open("tests/test_contract.py", "w") as fp:
-        fp.write(test)
-
-
-contract = """# Declare this file as a StarkNet contract and set the required
-# builtins.
-%lang starknet
-%builtins pedersen range_check
-
-from starkware.cairo.common.cairo_builtins import HashBuiltin
-from starkware.starknet.common.storage import Storage
-
-# Define a storage variable.
-@storage_var
-func balance() -> (res : felt):
-end
-
-# Increases the balance by the given amount.
-@external
-func increase_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount : felt):
-    let (res) = balance.read()
-    balance.write(res + amount)
-    return ()
-end
-
-# Returns the current balance.
-@view
-func get_balance{
-        storage_ptr : Storage*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res : felt):
-    let (res) = balance.read()
-    return (res)
-end
-"""
-
-
-test = """import os
-import pytest
-
-from starkware.starknet.testing.starknet import Starknet
-
-# The path to the contract source code.
-CONTRACT_FILE = os.path.join("contracts", "contract.cairo")
-
-
-# The testing library uses python's asyncio. So the following
-# decorator and the ``async`` keyword are needed.
-@pytest.mark.asyncio
-async def test_increase_balance():
-    # Create a new Starknet class that simulates the StarkNet
-    # system.
-    starknet = await Starknet.empty()
-
-    # Deploy the contract.
-    contract = await starknet.deploy(CONTRACT_FILE)
-
-    # Invoke increase_balance() twice.
-    await contract.increase_balance(amount=10).invoke()
-    await contract.increase_balance(amount=20).invoke()
-
-    # Check the result of get_balance().
-    assert await contract.get_balance().call() == (30,)
-"""
-
-makefile = """# Build and test
-build :; nile compile
-test  :; pytest tests/
-"""


### PR DESCRIPTION
This PR changes how `init` bootstraps a new project and also updates the sample tests and contracts to work with the latest Cairo release.