### PR TITLE
Change command output on compilation error

### DIFF
--- a/src/nile/commands/compile.py
+++ b/src/nile/commands/compile.py
@@ -25,7 +25,8 @@ def compile_command(contracts):
         all_contracts = get_all_contracts()
 
     results = [_compile_contract(contract) for contract in all_contracts]
-    failures = sum(r != 0 for r in results)
+    failed_contracts = [c for (c, r) in zip(all_contracts, results) if r != 0]
+    failures = len(failed_contracts)
 
     if failures == 0:
         print("✅ Done")
@@ -33,7 +34,9 @@ def compile_command(contracts):
         exp = f"{failures} contract"
         if failures > 1:
             exp += "s"  # pluralize
-        print(f"🛑 Failed to compile {exp}")
+        print(f"🛑 Failed to compile the following {exp}:")
+        for contract in failed_contracts:
+            print(f"   {contract}")
 
 
 def _compile_contract(path):

--- a/src/nile/commands/compile.py
+++ b/src/nile/commands/compile.py
@@ -18,17 +18,22 @@ def compile_command(contracts):
         print(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
         os.makedirs(ABIS_DIRECTORY, exist_ok=True)
 
+    all_contracts = contracts
+
     if len(contracts) == 0:
         print(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
-        for path in get_all_contracts():
-            _compile_contract(path)
-    elif len(contracts) == 1:
-        _compile_contract(contracts[0])
-    else:
-        for path in contracts:
-            _compile_contract(path)
+        all_contracts = get_all_contracts()
 
-    print("✅ Done")
+    results = [_compile_contract(contract) for contract in all_contracts]
+    failures = sum(r != 0 for r in results)
+
+    if failures == 0:
+        print("✅ Done")
+    else:
+        exp = f"{failures} contract"
+        if failures > 1:
+            exp += "s"  # pluralize
+        print(f"🛑 Failed to compile {exp}")
 
 
 def _compile_contract(path):
@@ -43,4 +48,5 @@ def _compile_contract(path):
         --abi {ABIS_DIRECTORY}/{filename}.json
     """
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
-    output, error = process.communicate()
+    process.communicate()
+    return process.returncode

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -19,9 +19,11 @@ def get_all_contracts(ext=None):
 
     files = list()
     for (dirpath, _, filenames) in os.walk(CONTRACTS_DIRECTORY):
-        files += [os.path.join(dirpath, file) for file in filenames]
+        files += [
+            os.path.join(dirpath, file) for file in filenames if file.endswith(ext)
+        ]
 
-    return filter(lambda file: file.endswith(ext), files)
+    return files
 
 
 def get_address_from(x):


### PR DESCRIPTION
Partially resolves #37. If there's a compilation error, `nile compile` now outputs this:

```
$ nile compile contracts/contract.cairo
🔨 Compiling contracts/contract.cairo
contracts/contract.cairo:19:5: Expected exactly 0 expressions, got 1.
    return (0)
    ^********^
🛑 Failed to compile 1 contract
```

I ran tox and it reported this is good to go, hopefully I didn't forget anything else.

The return value of `nile compile` is still 0 even on compilation failure. I'd rather do that part in a separate PR and on all commands, since I think it makes sense.

Happy to hear your thoughts.