### PR TITLE
Add tests for "compile" and "clean" CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode project settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -192,11 +192,17 @@ Nile uses tox to manage development tasks, you can get a list of
 available task with `tox -av`.
 
  * Install a development version of the package with `python -m pip install .`
- * Run tests with `tox`
  * Build the package with `tox -e build`
  * Format all files with `tox -e format`
  * Check files formatting with `tox -e lint`
 
+### Testing
+
+To run tests:
+ * Install testing dependencies with `python -m pip install .[testing]`
+ * Run all tests with `tox`
+ * To run a subset of tests, point to a specific module and/or function, e.g. `tox tests/test_module.py::test_function`
+ * Other `pytest` flags must be preceded by `--`, e.g. `tox -- --pdb` to run tests in debug mode
 
 ## License
 Nile is released under the MIT License.

--- a/src/nile/commands/clean.py
+++ b/src/nile/commands/clean.py
@@ -1,0 +1,28 @@
+"""Command to clean artifacts from workspace."""
+import os
+import shutil
+
+from nile.common import (
+    ACCOUNTS_FILENAME,
+    BUILD_DIRECTORY,
+    DEPLOYMENTS_FILENAME,
+)
+
+
+def clean_command():
+    """Remove artifacts from workspace."""
+    local_deployments_filename = f"localhost.{DEPLOYMENTS_FILENAME}"
+    local_accounts_filename = f"localhost.{ACCOUNTS_FILENAME}"
+
+    if os.path.exists(local_deployments_filename):
+        print(f"🚮 Deleting {local_deployments_filename}")
+        os.remove(local_deployments_filename)
+
+    if os.path.exists(local_accounts_filename):
+        print(f"🚮 Deleting {local_accounts_filename}")
+        os.remove(local_accounts_filename)
+
+    if os.path.exists(BUILD_DIRECTORY):
+        print(f"🚮 Deleting {BUILD_DIRECTORY} directory")
+        shutil.rmtree(BUILD_DIRECTORY)
+    print("✨ Workspace clean, keep going!")

--- a/src/nile/main.py
+++ b/src/nile/main.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 """Nile CLI entry point."""
-import os
-import shutil
-
 import click
 
 from nile.commands.account import (
@@ -11,6 +8,7 @@ from nile.commands.account import (
     account_setup_command,
 )
 from nile.commands.call import call_or_invoke_command
+from nile.commands.clean import clean_command
 from nile.commands.compile import compile_command
 from nile.commands.deploy import deploy_command
 from nile.commands.init import init_command
@@ -18,7 +16,6 @@ from nile.commands.install import install_command
 from nile.commands.node import node_command
 from nile.commands.test import test_command
 from nile.commands.version import version_command
-from nile.common import ACCOUNTS_FILENAME, BUILD_DIRECTORY, DEPLOYMENTS_FILENAME
 
 
 @click.group()
@@ -136,22 +133,7 @@ def compile(contracts):
 @cli.command()
 def clean():
     """Remove default build directory."""
-    local_deployments_filename = f"localhost.{DEPLOYMENTS_FILENAME}"
-    local_accounts_filename = f"localhost.{ACCOUNTS_FILENAME}"
-
-    if os.path.exists(local_deployments_filename):
-        print(f"🚮 Deleting {local_deployments_filename}")
-        os.remove(local_deployments_filename)
-
-    if os.path.exists(local_accounts_filename):
-        print(f"🚮 Deleting {local_accounts_filename}")
-        os.remove(local_accounts_filename)
-
-    if os.path.exists(BUILD_DIRECTORY):
-        print(f"🚮 Deleting {BUILD_DIRECTORY} directory")
-        shutil.rmtree(BUILD_DIRECTORY)
-
-    print("✨ Workspace clean, keep going!")
+    clean_command()
 
 
 @cli.command()

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -1,0 +1,51 @@
+"""Tests for clean command."""
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from nile.commands.clean import clean_command
+from nile.common import (
+    ACCOUNTS_FILENAME,
+    BUILD_DIRECTORY,
+    DEPLOYMENTS_FILENAME,
+)
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@patch("nile.commands.clean.shutil.rmtree")
+@patch("nile.commands.clean.os.remove")
+def test_clean_command_already_clean(mock_os_remove, mock_shutil_rmtree):
+    clean_command()
+    mock_os_remove.assert_not_called()
+    mock_shutil_rmtree.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        f"localhost.{ACCOUNTS_FILENAME}",
+        f"localhost.{DEPLOYMENTS_FILENAME}",
+    ],
+)
+@patch("nile.commands.clean.shutil.rmtree")
+@patch("nile.commands.clean.os.remove")
+def test_clean_command_clean_files(mock_os_remove, mock_shutil_rmtree, fname):
+    Path(fname).touch()
+    clean_command()
+    mock_os_remove.assert_called_once_with(fname)
+    mock_shutil_rmtree.assert_not_called()
+
+
+@patch("nile.commands.clean.shutil.rmtree")
+@patch("nile.commands.clean.os.remove")
+def test_clean_command_clean_build_dir(mock_os_remove, mock_shutil_rmtree):
+    Path(BUILD_DIRECTORY).mkdir()
+    clean_command()
+    mock_os_remove.assert_not_called()
+    mock_shutil_rmtree.assert_called_once_with(BUILD_DIRECTORY)

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -1,0 +1,84 @@
+"""
+Tests for compile command.
+
+Only unit tests for now. No contracts are actually compiled.
+"""
+from unittest.mock import Mock, patch
+
+import pytest
+
+from nile.common import ABIS_DIRECTORY, CONTRACTS_DIRECTORY
+from nile.commands.compile import _compile_contract, compile_command
+
+CONTRACT = "foo.cairo"
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+# Mock `subprocess` for all tests in this module to avoid actually running any
+# shell commands.
+@pytest.fixture(autouse=True)
+def mock_subprocess():
+    with patch("nile.commands.compile.subprocess") as mock_subprocess:
+        yield mock_subprocess
+
+
+def test_compile_command_create_abis_directory(tmp_working_dir):
+    assert not (tmp_working_dir / ABIS_DIRECTORY).exists()
+    compile_command([])
+    assert (tmp_working_dir / ABIS_DIRECTORY).exists()
+
+
+@patch("nile.commands.compile.get_all_contracts")
+def test_compile_command_get_all_contracts_called(mock_get_all_contracts):
+    compile_command([])
+    mock_get_all_contracts.assert_called_once()
+    mock_get_all_contracts.reset_mock()
+
+    compile_command([CONTRACT])
+    mock_get_all_contracts.assert_not_called()
+
+
+@patch("nile.commands.compile._compile_contract")
+def test_compile_command__compile_contract_called(mock__compile_contract):
+    compile_command([CONTRACT])
+    mock__compile_contract.assert_called_once_with(CONTRACT)
+
+
+@patch("nile.commands.compile._compile_contract")
+def test_compile_command_failure_feedback(mock__compile_contract, capsys):
+    mock__compile_contract.side_effect = [0]
+    compile_command([CONTRACT])
+    assert "Done" in capsys.readouterr().out
+
+    mock__compile_contract.side_effect = [1]
+    compile_command([CONTRACT])
+    assert "Failed" in capsys.readouterr().out
+
+
+def test__compile_contract(mock_subprocess):
+    contract_name_root = "contract"
+    path = f"path/to/{contract_name_root}.cairo"
+
+    mock_process = Mock()
+    mock_subprocess.Popen.return_value = mock_process
+
+    _compile_contract(path)
+
+    mock_subprocess.Popen.assert_called_once_with(
+        [
+            "starknet-compile",
+            path,
+            f"--cairo_path={CONTRACTS_DIRECTORY}",
+            "--output",
+            f"artifacts/{contract_name_root}.json",
+            "--abi",
+            f"artifacts/abis/{contract_name_root}.json",
+        ],
+        stdout=mock_subprocess.PIPE,
+    )
+    mock_process.communicate.assert_called_once()

--- a/tests/commands/test_test.py
+++ b/tests/commands/test_test.py
@@ -1,5 +1,0 @@
-"""Test the test command."""
-
-
-def test_test():
-    assert True


### PR DESCRIPTION
See https://github.com/OpenZeppelin/nile/issues/13

- Extracts `clean` command implementation to make it easier to test.
- Contract compilation itself is not tested.

Looks like I cannot assign reviewers, but as this is not time critical I'm just leaving it here for now:)
