### PR TITLE
Prevent truncation of 2 trailing characters

### DIFF
--- a/src/nile/commands/deploy.py
+++ b/src/nile/commands/deploy.py
@@ -42,6 +42,6 @@ def deploy_command(contract_name, arguments, network, alias, overriding_path=Non
 
 def parse_deployment(x):
     """Extract information from deployment command."""
-    # address is 64, tx_hash is 62 chars long
-    address, tx_hash = re.findall("0x[\\da-f]{1,62}", str(x))
+    # address is 64, tx_hash is 64 chars long
+    address, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
     return address, tx_hash


### PR DESCRIPTION
Error: `nile invoke xyz` results in `UNINITIALIZED_CONTRACT`.

Issue: When storing the contract address in `*.deployments.txt` the trailing two characters are omitted. When calling invoke on a contract verified to be deployed (e.g., on Voyager, address `0x123`), the contract printed to the console has two leading  0's: `0x00123`. The length of the address (excluding 0x prefix) appears to be 64 elsewhere (StarkNet CLI, Voyager).

Resolution: Increase the max length of the regex.