### PR TITLE
Add end-to-end tests for "compile" and "clean" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ available task with `tox -av`.
 To run tests:
  * Install testing dependencies with `python -m pip install .[testing]`
  * Run all tests with `tox`
- * To run a subset of tests, point to a specific module and/or function, e.g. `tox tests/test_module.py::test_function`
+ * Run unit tests only with `tox -e unit`
+ * To run a specific set of tests, point to a module and/or function, e.g. `tox tests/test_module.py::test_function`
  * Other `pytest` flags must be preceded by `--`, e.g. `tox -- --pdb` to run tests in debug mode
 
 ## License

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,8 @@ console_scripts =
 addopts =
     --cov nile --cov-report term-missing
     --verbose
+markers =
+    end_to_end: End-to-end tests, potentially slow.
 norecursedirs =
     dist
     build

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ exclude =
 
 [options.extras_require]
 testing =
+    cairo-lang
     setuptools
     tox
     twine

--- a/tests/resources/contracts/contract.cairo
+++ b/tests/resources/contracts/contract.cairo
@@ -1,0 +1,30 @@
+# Declare this file as a StarkNet contract and set the required
+# builtins.
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+# Define a storage variable.
+@storage_var
+func balance() -> (res : felt):
+end
+
+# Increases the balance by the given amount.
+@external
+func increase_balance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}(amount : felt):
+    let (res) = balance.read()
+    balance.write(res + amount)
+    return ()
+end
+
+# Returns the current balance.
+@view
+func get_balance{
+        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
+        range_check_ptr}() -> (res : felt):
+    let (res) = balance.read()
+    return (res)
+end

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 """Tests for main.py."""
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -38,6 +39,11 @@ def test_clean():
         (["contract_1.cairo"], {"contract_1.json"}),
         (["contract_2.cairo"], {"contract_2.json"}),
     ],
+)
+@pytest.mark.xfail(
+    sys.version_info >= (3, 10),
+    reason="Issue in cairo-lang. "
+    "See https://github.com/starkware-libs/cairo-lang/issues/27",
 )
 def test_compile(args, expected):
     contract_source = RESOURCES_DIR / "contracts" / "contract.cairo"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,51 @@
+"""Tests for main.py."""
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from nile.common import (
+    ABIS_DIRECTORY,
+    BUILD_DIRECTORY,
+    CONTRACTS_DIRECTORY,
+)
+from nile.main import cli
+
+RESOURCES_DIR = Path(__file__).parent / "resources"
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], {"contract_1.json", "contract_2.json"}),
+        (["contract_1.cairo"], {"contract_1.json"}),
+        (["contract_2.cairo"], {"contract_2.json"}),
+    ],
+)
+def test_compile(args, expected):
+    contract_source = RESOURCES_DIR / "contracts" / "contract.cairo"
+
+    target_dir = Path(CONTRACTS_DIRECTORY)
+    target_dir.mkdir()
+
+    shutil.copyfile(contract_source, target_dir / "contract_1.cairo")
+    shutil.copyfile(contract_source, target_dir / "contract_2.cairo")
+
+    abi_dir = Path(ABIS_DIRECTORY)
+    build_dir = Path(BUILD_DIRECTORY)
+
+    assert not abi_dir.exists()
+    assert not build_dir.exists()
+
+    result = CliRunner().invoke(cli, ["compile", *args])
+    assert result.exit_code == 0
+
+    assert {f.name for f in abi_dir.glob("*.json")} == expected
+    assert {f.name for f in build_dir.glob("*.json")} == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -15,6 +15,9 @@ from nile.main import cli
 RESOURCES_DIR = Path(__file__).parent / "resources"
 
 
+pytestmark = pytest.mark.end_to_end
+
+
 @pytest.fixture(autouse=True)
 def tmp_working_dir(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -21,6 +21,13 @@ def tmp_working_dir(monkeypatch, tmp_path):
     return tmp_path
 
 
+def test_clean():
+    # The implementation is already thoroughly covered by unit tests, so here
+    # we just check whether the command completes successfully.
+    result = CliRunner().invoke(cli, ["clean"])
+    assert result.exit_code == 0
+
+
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,11 @@ extras =
 commands =
     pytest {posargs}
 
+[testenv:unit]
+description = Invoke pytest to run unit tests
+commands =
+    pytest -m "not end_to_end" {posargs}
+
 [testenv:build]
 description = Build the package in isolation according to PEP517, see https://github.com/pypa/build
 skip_install = True


### PR DESCRIPTION
See https://github.com/OpenZeppelin/nile/issues/41

Adds end-to-end tests for `nile compile` and `nile clean`. The latter was already pretty well covered by unit tests, so the test here is minimal.

Not sure about the best way to use markers here to in or exclude end-to-end tests. All feedback is welcome:)
