### PR TITLE
Add host and port options for "node" command

### DIFF
--- a/src/nile/commands/deploy.py
+++ b/src/nile/commands/deploy.py
@@ -4,9 +4,7 @@ import re
 import subprocess
 
 from nile import deployments
-from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY
-
-GATEWAYS = {"localhost": "http://localhost:5000/"}
+from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
 
 
 def deploy_command(contract_name, arguments, network, alias, overriding_path=None):

--- a/src/nile/commands/node.py
+++ b/src/nile/commands/node.py
@@ -1,11 +1,24 @@
 """Command to start StarkNet local network."""
 import subprocess
+import json
+from nile.common import NODE_FILENAME
 
 
-def node_command():
+def node_command(host="localhost", port=5000):
     """Start StarkNet local network."""
     try:
-        subprocess.check_call("starknet-devnet")
+        # Save host and port information to be used by other commands
+        file = NODE_FILENAME
+        network = host
+        gateway_url = f"http://{host}:{port}/"
+        gateway = {network: gateway_url}
+
+        with open(file, "w+") as f:
+            json.dump(gateway, f)
+
+        # Start network
+        subprocess.check_call(["starknet-devnet", "--host", host, "--port", str(port)])
+
     except FileNotFoundError:
         print("")
         print("😰 Could not find starknet-devnet, is it installed? Try with:\n")

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -1,5 +1,6 @@
 """nile common module."""
 import os
+import json
 
 CONTRACTS_DIRECTORY = "contracts"
 BUILD_DIRECTORY = "artifacts"
@@ -9,7 +10,20 @@ DEPLOYMENTS_FILENAME = "deployments.txt"
 ACCOUNTS_FILENAME = "accounts.json"
 NODE_FILENAME = "node.json"
 
-GATEWAYS = {"localhost": "http://localhost:5000/"}
+
+def _get_gateway():
+    """Get the StarkNet node details."""
+    try:
+        with open(NODE_FILENAME, "r") as f:
+            gateway = json.load(f)
+            return gateway
+
+    except FileNotFoundError:
+        with open(NODE_FILENAME, "w") as f:
+            f.write('{"localhost": "http://localhost:5000/"}')
+
+
+GATEWAYS = _get_gateway()
 
 
 def get_all_contracts(ext=None):

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -7,6 +7,7 @@ TEMP_DIRECTORY = ".temp"
 ABIS_DIRECTORY = f"{BUILD_DIRECTORY}/abis"
 DEPLOYMENTS_FILENAME = "deployments.txt"
 ACCOUNTS_FILENAME = "accounts.json"
+NODE_FILENAME = "node.json"
 
 GATEWAYS = {"localhost": "http://localhost:5000/"}
 

--- a/src/nile/main.py
+++ b/src/nile/main.py
@@ -137,9 +137,18 @@ def clean():
 
 
 @cli.command()
-def node():
-    """Start StarkNet local network."""
-    node_command()
+@click.option("--host", default="localhost")
+@click.option("--port", default=5000)
+def node(host, port):
+    """Start StarkNet local network.
+
+    $ nile node
+      Start StarkNet local network at port 5000
+
+    $ nile node --host HOST --port 5001
+      Start StarkNet network on address HOST listening at port 5001
+    """
+    node_command(host, port)
 
 
 @cli.command()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,16 @@
 """Tests for main.py."""
 import shutil
 import sys
+import json
 from pathlib import Path
+from multiprocessing import Process
+from threading import Timer
+from os import kill, getpid
+from signal import SIGINT
+from urllib.request import urlopen
+from urllib.error import URLError
+
+from time import sleep
 
 import pytest
 from click.testing import CliRunner
@@ -10,6 +19,7 @@ from nile.common import (
     ABIS_DIRECTORY,
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
+    NODE_FILENAME,
 )
 from nile.main import cli
 
@@ -23,6 +33,30 @@ pytestmark = pytest.mark.end_to_end
 def tmp_working_dir(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     return tmp_path
+
+
+def create_process(target, args):
+    """Spawns another process in Python."""
+    p = Process(target=target, args=args)
+    return p
+
+
+def start_node(seconds, node_args):
+    """Start node with host and port specified in node_args and life in seconds."""
+    # Timed kill command with SIGINT to close Node process
+    Timer(seconds, lambda: kill(getpid(), SIGINT)).start()
+    CliRunner().invoke(cli, ["node", *node_args])
+
+
+def check_node(p, gateway_url):
+    """Check if node is running while spawned process is alive."""
+    while p.is_alive:
+        try:
+            status = urlopen(gateway_url + "is_alive").getcode()
+            return status
+        except URLError:
+            sleep(1)
+            continue
 
 
 def test_clean():
@@ -65,3 +99,44 @@ def test_compile(args, expected):
 
     assert {f.name for f in abi_dir.glob("*.json")} == expected
     assert {f.name for f in build_dir.glob("*.json")} == expected
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], "http://localhost:5000/"),
+        (["--host", "localhost", "--port", "5001"], "http://localhost:5001/"),
+    ],
+)
+@pytest.mark.xfail(
+    sys.version_info >= (3, 10),
+    reason="Issue in cairo-lang. "
+    "See https://github.com/starkware-libs/cairo-lang/issues/27",
+)
+def test_node(args, expected):
+    # Node life
+    seconds = 8
+
+    if args == []:
+        host, port = "localhost", 5000
+    else:
+        host, port = args[1], int(args[3])
+
+    network = host
+    gateway_url = f"http://{host}:{port}/"
+
+    # Spawn process to start StarkNet local network with specified port
+    # i.e. $ nile node --host localhost --port 5001
+    p = create_process(target=start_node, args=(seconds, args))
+    p.start()
+
+    # Check node heartbeat and assert that it is running
+    status = check_node(p, gateway_url)
+    p.join()
+    assert status == 200
+
+    # Assert network and gateway_url is correct in node.json file
+    file = NODE_FILENAME
+    with open(file, "r") as f:
+        gateway = json.load(f)
+    assert gateway.get(network) == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,13 +48,15 @@ def start_node(seconds, node_args):
     CliRunner().invoke(cli, ["node", *node_args])
 
 
-def check_node(p, gateway_url):
+def check_node(p, seconds, gateway_url):
     """Check if node is running while spawned process is alive."""
-    while p.is_alive:
+    check_runs = 0
+    while p.is_alive and check_runs < seconds:
         try:
             status = urlopen(gateway_url + "is_alive").getcode()
             return status
         except URLError:
+            check_runs += 1
             sleep(1)
             continue
 
@@ -131,7 +133,7 @@ def test_node(args, expected):
     p.start()
 
     # Check node heartbeat and assert that it is running
-    status = check_node(p, gateway_url)
+    status = check_node(p, seconds, gateway_url)
     p.join()
     assert status == 200
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ passenv =
     HOME
 extras =
     testing
+deps =
+    starknet-devnet
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
Hi there,

Kindly see #35. I've added an option to customize the host and node port when running `nile node` and an end-to-end test in `test_main.py`

Running the command `nile node --host localhost --port 5001` should yield something like this

<img width="443" alt="image" src="https://user-images.githubusercontent.com/35031356/147954693-80a35ba8-cff9-490f-970c-98b59d655761.png">

Please let me know if this looks alright and any feedback is welcome, thanks! 🙂