### PR TITLE
Add setup.py to enable editable install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    try:
+        setup(use_scm_version={"version_scheme": "no-guess-dev"})
+    except:  # noqa
+        print(
+            "\n\nAn error occurred while building the project, "
+            "please ensure you have the most updated version of setuptools, "
+            "setuptools_scm and wheel with:\n"
+            "   pip install -U setuptools setuptools_scm wheel\n\n"
+        )
+        raise


### PR DESCRIPTION
At the moment, it's not possible to have an editable installation of nile (aka `pip install -e .[testing]`). I added a minimal `setup.py` that integrates with `setup.cfg` to enable this.