### PR TITLE
Scripting API prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ Execute a script in the context of Nile. The script must implement a `run(nre)` 
 # path/to/script.py
 
 def run(nre):
-    nre.deploy("contract", alias="my_contract")
-    address, abi = nre.get_deployment('my_contract')
+    address, abi = nre.deploy("contract", alias="my_contract")
     print(abi, address)
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,24 @@ nile call my_contract get_balance
 1
 ```
 
+### `run`
+Execute a script in the context of Nile. The script must implement a `run(nre)` function to receive a `NileRuntimeEnvironment` object exposing Nile's scripting API.
+
+```python
+# path/to/script.py
+
+def run(nre):
+    nre.deploy("contract", alias="my_contract")
+    address, abi = nre.get_deployment('my_contract')
+    print(abi, address)
+```
+
+Then run the script:
+
+```sh
+nile run path/to/script.py
+```
+
 ### `clean`
 Deletes the `artifacts/` directory for a fresh start ❄️
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ testing =
 
 [options.entry_points]
 console_scripts =
-    nile = nile.main:cli
+    nile = nile.cli:cli
 
 [tool:pytest]
 addopts =

--- a/src/nile/__init__.py
+++ b/src/nile/__init__.py
@@ -1,14 +1,5 @@
 """StarkNet/Cairo development toolbelt."""
 
-from nile.core.account import (
-    account_raw_execute,
-    account_send,
-    account_setup,
-)
-from nile.core.call_or_invoke import call_or_invoke
-from nile.core.compile import compile
-from nile.core.deploy import deploy
-
 try:
     from importlib import metadata as importlib_metadata
 except ImportError:

--- a/src/nile/__init__.py
+++ b/src/nile/__init__.py
@@ -1,5 +1,14 @@
 """StarkNet/Cairo development toolbelt."""
 
+from nile.core.account import (
+    account_raw_execute,
+    account_send,
+    account_setup,
+)
+from nile.core.call_or_invoke import call_or_invoke
+from nile.core.compile import compile
+from nile.core.deploy import deploy
+
 try:
     from importlib import metadata as importlib_metadata
 except ImportError:

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -2,11 +2,7 @@
 """Nile CLI entry point."""
 import click
 
-from nile.core.account import (
-    account_raw_execute,
-    account_send,
-    account_setup,
-)
+from nile.core.account import account_raw_execute, account_send, account_setup
 from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
@@ -14,6 +10,7 @@ from nile.core.deploy import deploy as deploy_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command
+from nile.core.run import run as run_command
 from nile.core.test import test as test_command
 from nile.core.version import version as version_command
 
@@ -34,6 +31,14 @@ def init():
 def install():
     """Install Cairo."""
     install_command()
+
+
+@cli.command()
+@click.argument("path", nargs=1)
+@click.option("--network", default="localhost")
+def run(path, network):
+    """Run Nile scripts with NileRuntimeEnvironment."""
+    run_command(path, network)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 """Nile CLI entry point."""
+import logging
+
 import click
 
 from nile.core.account import account_raw_execute, account_send, account_setup
@@ -13,6 +15,8 @@ from nile.core.node import node as node_command
 from nile.core.run import run as run_command
 from nile.core.test import test as test_command
 from nile.core.version import version as version_command
+
+logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 
 @click.group()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -2,20 +2,20 @@
 """Nile CLI entry point."""
 import click
 
-from nile.commands.account import (
-    account_raw_execute_command,
-    account_send_command,
-    account_setup_command,
+from nile.core.account import (
+    account_raw_execute,
+    account_send,
+    account_setup,
 )
-from nile.commands.call import call_or_invoke_command
-from nile.commands.clean import clean_command
-from nile.commands.compile import compile_command
-from nile.commands.deploy import deploy_command
-from nile.commands.init import init_command
-from nile.commands.install import install_command
-from nile.commands.node import node_command
-from nile.commands.test import test_command
-from nile.commands.version import version_command
+from nile.core.call_or_invoke import call_or_invoke as casll_or_invoke_command
+from nile.core.clean import clean as clean_command
+from nile.core.compile import compile as compile_command
+from nile.core.deploy import deploy as deploy_comand
+from nile.core.init import init as init_command
+from nile.core.install import install as install_command
+from nile.core.node import node as node_command
+from nile.core.test import test as test_command
+from nile.core.version import version as version_command
 
 
 @click.group()
@@ -43,7 +43,7 @@ def install():
 @click.option("--alias")
 def deploy(artifact, arguments, network, alias):
     """Deploy StarkNet smart contract."""
-    deploy_command(artifact, arguments, network, alias)
+    deploy_comand(artifact, arguments, network, alias)
 
 
 @cli.command()
@@ -54,7 +54,7 @@ def deploy(artifact, arguments, network, alias):
 @click.option("--network", default="localhost")
 def send(signer, contract_name, method, params, network):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
-    account_send_command(signer, contract_name, method, params, network)
+    account_send(signer, contract_name, method, params, network)
 
 
 @cli.command(name="raw-execute")
@@ -63,7 +63,7 @@ def send(signer, contract_name, method, params, network):
 @click.option("--network", default="localhost")
 def raw_execute(signer, params, network):
     """Invoke a contract through an Account."""
-    account_raw_execute_command(signer, params, network)
+    account_raw_execute(signer, params, network)
 
 
 @cli.command()
@@ -71,7 +71,7 @@ def raw_execute(signer, params, network):
 @click.option("--network", default="localhost")
 def setup(signer, network):
     """Do setup an Account contract."""
-    account_setup_command(signer, network)
+    account_setup(signer, network)
 
 
 @cli.command()
@@ -81,7 +81,7 @@ def setup(signer, network):
 @click.option("--network", default="localhost")
 def invoke(contract_name, method, params, network):
     """Invoke functions of StarkNet smart contracts."""
-    call_or_invoke_command(contract_name, "invoke", method, params, network)
+    casll_or_invoke_command(contract_name, "invoke", method, params, network)
 
 
 @cli.command()
@@ -91,7 +91,7 @@ def invoke(contract_name, method, params, network):
 @click.option("--network", default="localhost")
 def call(contract_name, method, params, network):
     """Call functions of StarkNet smart contracts."""
-    call_or_invoke_command(contract_name, "call", method, params, network)
+    casll_or_invoke_command(contract_name, "call", method, params, network)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -7,10 +7,10 @@ from nile.core.account import (
     account_send,
     account_setup,
 )
-from nile.core.call_or_invoke import call_or_invoke as casll_or_invoke_command
+from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
-from nile.core.deploy import deploy as deploy_comand
+from nile.core.deploy import deploy as deploy_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command
@@ -43,7 +43,7 @@ def install():
 @click.option("--alias")
 def deploy(artifact, arguments, network, alias):
     """Deploy StarkNet smart contract."""
-    deploy_comand(artifact, arguments, network, alias)
+    deploy_command(artifact, arguments, network, alias)
 
 
 @cli.command()
@@ -81,7 +81,7 @@ def setup(signer, network):
 @click.option("--network", default="localhost")
 def invoke(contract_name, method, params, network):
     """Invoke functions of StarkNet smart contracts."""
-    casll_or_invoke_command(contract_name, "invoke", method, params, network)
+    call_or_invoke_command(contract_name, "invoke", method, params, network)
 
 
 @cli.command()
@@ -91,7 +91,7 @@ def invoke(contract_name, method, params, network):
 @click.option("--network", default="localhost")
 def call(contract_name, method, params, network):
     """Call functions of StarkNet smart contracts."""
-    casll_or_invoke_command(contract_name, "call", method, params, network)
+    call_or_invoke_command(contract_name, "call", method, params, network)
 
 
 @cli.command()

--- a/src/nile/commands/__init__.py
+++ b/src/nile/commands/__init__.py
@@ -1,1 +1,0 @@
-"""Nile commands implementations."""

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -1,6 +1,6 @@
 """nile common module."""
-import os
 import json
+import os
 
 CONTRACTS_DIRECTORY = "contracts"
 BUILD_DIRECTORY = "artifacts"
@@ -38,10 +38,3 @@ def get_all_contracts(ext=None):
         ]
 
     return files
-
-
-def logger(verbose):
-    def log(msg):
-        if verbose:
-            print(msg)
-    return log

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -38,3 +38,10 @@ def get_all_contracts(ext=None):
         ]
 
     return files
+
+
+def logger(verbose):
+    def log(msg):
+        if verbose:
+            print(msg)
+    return log

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -5,8 +5,8 @@ import subprocess
 from dotenv import load_dotenv
 
 from nile import accounts, deployments
-from nile.core.deploy import deploy
 from nile.common import GATEWAYS
+from nile.core.deploy import deploy
 from nile.signer import Signer
 
 load_dotenv()

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -5,14 +5,14 @@ import subprocess
 from dotenv import load_dotenv
 
 from nile import accounts, deployments
-from nile.commands.deploy import deploy_command
+from nile.core.deploy import deploy
 from nile.common import GATEWAYS
 from nile.signer import Signer
 
 load_dotenv()
 
 
-def account_setup_command(signer, network):
+def account_setup(signer, network):
     """Deploy an Account contract for the given private key."""
     signer = Signer(int(os.environ[signer]), network)
     if accounts.exists(str(signer.public_key), network):
@@ -23,7 +23,7 @@ def account_setup_command(signer, network):
         signer.index = accounts.current_index(network)
         pt = os.path.dirname(os.path.realpath(__file__)).replace("/commands", "")
         overriding_path = (f"{pt}/artifacts", f"{pt}/artifacts/abis")
-        deploy_command(
+        deploy(
             "Account",
             [str(signer.public_key)],
             network,
@@ -37,17 +37,17 @@ def account_setup_command(signer, network):
     return signer
 
 
-def account_send_command(signer, contract, method, params, network):
+def account_send(signer, contract, method, params, network):
     """Sugared call to a contract passing by an Account contract."""
     address, abi = next(deployments.load(contract, network))
     concatened_params = [address, method] + list(params)
-    return account_raw_execute_command(signer, concatened_params, network)
+    return account_raw_execute(signer, concatened_params, network)
 
 
-def account_raw_execute_command(signer, params, network):
+def account_raw_execute(signer, params, network):
     """Execute a tx going through an Account contract."""
     # params are : to, selector_name, calldata
-    signer = account_setup_command(signer, network)
+    signer = account_setup(signer, network)
 
     _, abi = next(deployments.load(f"account-{signer.index}", network))
 

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -6,7 +6,7 @@ from nile import deployments
 from nile.common import GATEWAYS
 
 
-def call_or_invoke_command(contract, type, method, params, network):
+def call_or_invoke(contract, type, method, params, network):
     """Call or invoke functions of StarkNet smart contracts."""
     address, abi = next(deployments.load(contract, network))
 

--- a/src/nile/core/clean.py
+++ b/src/nile/core/clean.py
@@ -2,11 +2,7 @@
 import os
 import shutil
 
-from nile.common import (
-    ACCOUNTS_FILENAME,
-    BUILD_DIRECTORY,
-    DEPLOYMENTS_FILENAME,
-)
+from nile.common import ACCOUNTS_FILENAME, BUILD_DIRECTORY, DEPLOYMENTS_FILENAME
 
 
 def clean():

--- a/src/nile/core/clean.py
+++ b/src/nile/core/clean.py
@@ -1,4 +1,5 @@
 """Command to clean artifacts from workspace."""
+import logging
 import os
 import shutil
 
@@ -11,14 +12,14 @@ def clean():
     local_accounts_filename = f"localhost.{ACCOUNTS_FILENAME}"
 
     if os.path.exists(local_deployments_filename):
-        print(f"🚮 Deleting {local_deployments_filename}")
+        logging.info(f"🚮 Deleting {local_deployments_filename}")
         os.remove(local_deployments_filename)
 
     if os.path.exists(local_accounts_filename):
-        print(f"🚮 Deleting {local_accounts_filename}")
+        logging.info(f"🚮 Deleting {local_accounts_filename}")
         os.remove(local_accounts_filename)
 
     if os.path.exists(BUILD_DIRECTORY):
-        print(f"🚮 Deleting {BUILD_DIRECTORY} directory")
+        logging.info(f"🚮 Deleting {BUILD_DIRECTORY} directory")
         shutil.rmtree(BUILD_DIRECTORY)
-    print("✨ Workspace clean, keep going!")
+    logging.info("✨ Workspace clean, keep going!")

--- a/src/nile/core/clean.py
+++ b/src/nile/core/clean.py
@@ -9,7 +9,7 @@ from nile.common import (
 )
 
 
-def clean_command():
+def clean():
     """Remove artifacts from workspace."""
     local_deployments_filename = f"localhost.{DEPLOYMENTS_FILENAME}"
     local_accounts_filename = f"localhost.{ACCOUNTS_FILENAME}"

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -7,23 +7,21 @@ from nile.common import (
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
     get_all_contracts,
-    logger
 )
 
 
 def compile(contracts, verbose=False):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
-    log = logger(verbose)
 
     if not os.path.exists(ABIS_DIRECTORY):
-        log(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
+        print(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
         os.makedirs(ABIS_DIRECTORY, exist_ok=True)
 
     all_contracts = contracts
 
     if len(contracts) == 0:
-        log(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
+        print(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
         all_contracts = get_all_contracts()
 
     results = [_compile_contract(contract) for contract in all_contracts]
@@ -31,21 +29,20 @@ def compile(contracts, verbose=False):
     failures = len(failed_contracts)
 
     if failures == 0:
-        log("✅ Done")
+        print("✅ Done")
     else:
         exp = f"{failures} contract"
         if failures > 1:
             exp += "s"  # pluralize
-        log(f"🛑 Failed to compile the following {exp}:")
+        print(f"🛑 Failed to compile the following {exp}:")
         for contract in failed_contracts:
-            log(f"   {contract}")
+            print(f"   {contract}")
 
 
 def _compile_contract(path, verbose=False):
-    log = logger(verbose)
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
-    log(f"🔨 Compiling {path}")
+    print(f"🔨 Compiling {path}")
 
     cmd = f"""
     starknet-compile {path} \

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -1,4 +1,5 @@
 """Command to compile cairo files."""
+import logging
 import os
 import subprocess
 
@@ -10,18 +11,20 @@ from nile.common import (
 )
 
 
-def compile(contracts, verbose=False):
+def compile(contracts):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
 
     if not os.path.exists(ABIS_DIRECTORY):
-        print(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
+        logging.info(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
         os.makedirs(ABIS_DIRECTORY, exist_ok=True)
 
     all_contracts = contracts
 
     if len(contracts) == 0:
-        print(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
+        logging.info(
+            f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory"
+        )
         all_contracts = get_all_contracts()
 
     results = [_compile_contract(contract) for contract in all_contracts]
@@ -29,20 +32,20 @@ def compile(contracts, verbose=False):
     failures = len(failed_contracts)
 
     if failures == 0:
-        print("✅ Done")
+        logging.info("✅ Done")
     else:
         exp = f"{failures} contract"
         if failures > 1:
             exp += "s"  # pluralize
-        print(f"🛑 Failed to compile the following {exp}:")
+        logging.info(f"🛑 Failed to compile the following {exp}:")
         for contract in failed_contracts:
-            print(f"   {contract}")
+            logging.info(f"   {contract}")
 
 
-def _compile_contract(path, verbose=False):
+def _compile_contract(path):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
-    print(f"🔨 Compiling {path}")
+    logging.info(f"🔨 Compiling {path}")
 
     cmd = f"""
     starknet-compile {path} \

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -7,21 +7,23 @@ from nile.common import (
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
     get_all_contracts,
+    logger
 )
 
 
-def compile_command(contracts):
+def compile(contracts, verbose=False):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
+    log = logger(verbose)
 
     if not os.path.exists(ABIS_DIRECTORY):
-        print(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
+        log(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
         os.makedirs(ABIS_DIRECTORY, exist_ok=True)
 
     all_contracts = contracts
 
     if len(contracts) == 0:
-        print(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
+        log(f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory")
         all_contracts = get_all_contracts()
 
     results = [_compile_contract(contract) for contract in all_contracts]
@@ -29,20 +31,21 @@ def compile_command(contracts):
     failures = len(failed_contracts)
 
     if failures == 0:
-        print("✅ Done")
+        log("✅ Done")
     else:
         exp = f"{failures} contract"
         if failures > 1:
             exp += "s"  # pluralize
-        print(f"🛑 Failed to compile the following {exp}:")
+        log(f"🛑 Failed to compile the following {exp}:")
         for contract in failed_contracts:
-            print(f"   {contract}")
+            log(f"   {contract}")
 
 
-def _compile_contract(path):
+def _compile_contract(path, verbose=False):
+    log = logger(verbose)
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
-    print(f"🔨 Compiling {path}")
+    log(f"🔨 Compiling {path}")
 
     cmd = f"""
     starknet-compile {path} \

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -4,12 +4,13 @@ import re
 import subprocess
 
 from nile import deployments
-from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
+from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS, logger
 
 
-def deploy_command(contract_name, arguments, network, alias, overriding_path=None):
+def deploy(contract_name, arguments, network, alias, overriding_path=None, verbose=False):
     """Deploy StarkNet smart contracts."""
-    print(f"🚀 Deploying {contract_name}")
+    log = logger(verbose)
+    log(f"🚀 Deploying {contract_name}")
 
     base_path = (
         overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
@@ -32,8 +33,8 @@ def deploy_command(contract_name, arguments, network, alias, overriding_path=Non
 
     output = subprocess.check_output(command)
     address, tx_hash = parse_deployment(output)
-    print(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
-    print(f"🧾 Transaction hash: {tx_hash}")
+    log(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
+    log(f"🧾 Transaction hash: {tx_hash}")
 
     deployments.register(address, abi, network, alias)
 

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -1,4 +1,5 @@
 """Command to deploy StarkNet smart contracts."""
+import logging
 import os
 import re
 import subprocess
@@ -9,7 +10,7 @@ from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
 
 def deploy(contract_name, arguments, network, alias, overriding_path=None):
     """Deploy StarkNet smart contracts."""
-    print(f"🚀 Deploying {contract_name}")
+    logging.info(f"🚀 Deploying {contract_name}")
 
     base_path = (
         overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
@@ -32,10 +33,11 @@ def deploy(contract_name, arguments, network, alias, overriding_path=None):
 
     output = subprocess.check_output(command)
     address, tx_hash = parse_deployment(output)
-    print(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
-    print(f"🧾 Transaction hash: {tx_hash}")
+    logging.info(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
+    logging.info(f"🧾 Transaction hash: {tx_hash}")
 
     deployments.register(address, abi, network, alias)
+    return address, abi
 
 
 def parse_deployment(x):

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -4,13 +4,12 @@ import re
 import subprocess
 
 from nile import deployments
-from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS, logger
+from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
 
 
-def deploy(contract_name, arguments, network, alias, overriding_path=None, verbose=False):
+def deploy(contract_name, arguments, network, alias, overriding_path=None):
     """Deploy StarkNet smart contracts."""
-    log = logger(verbose)
-    log(f"🚀 Deploying {contract_name}")
+    print(f"🚀 Deploying {contract_name}")
 
     base_path = (
         overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
@@ -33,8 +32,8 @@ def deploy(contract_name, arguments, network, alias, overriding_path=None, verbo
 
     output = subprocess.check_output(command)
     address, tx_hash = parse_deployment(output)
-    log(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
-    log(f"🧾 Transaction hash: {tx_hash}")
+    print(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
+    print(f"🧾 Transaction hash: {tx_hash}")
 
     deployments.register(address, abi, network, alias)
 

--- a/src/nile/core/init.py
+++ b/src/nile/core/init.py
@@ -4,10 +4,10 @@ import sys
 from distutils.dir_util import copy_tree
 from pathlib import Path
 
-from nile.commands.install import install_command
+from nile.core.install import install
 
 
-def init_command():
+def init():
     """Kickstart a new Nile project."""
     # install cairo dependencies
     subprocess.check_call(
@@ -15,7 +15,7 @@ def init_command():
     )
 
     # install cairo within env
-    install_command()
+    install()
 
     # install testing dependencies
     subprocess.check_call(

--- a/src/nile/core/init.py
+++ b/src/nile/core/init.py
@@ -1,4 +1,5 @@
 """Command to kickstart a Nile project."""
+import logging
 import subprocess
 import sys
 from distutils.dir_util import copy_tree
@@ -21,18 +22,18 @@ def init():
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "pytest", "pytest-asyncio"]
     )
-    print("")
-    print("✅ Dependencies successfully installed")
+    logging.info("")
+    logging.info("✅ Dependencies successfully installed")
 
     # create project directories
-    print("🗄  Creating project directory tree")
+    logging.info("🗄  Creating project directory tree")
 
     copy_tree(Path(__file__).parent.parent / "base_project", ".")
 
     with open("accounts.json", "w") as file:
         file.write("{}")
 
-    print("⛵️ Nile project ready! Try running:")
-    print("")
-    print("nile compile")
-    print("")
+    logging.info("⛵️ Nile project ready! Try running:")
+    logging.info("")
+    logging.info("nile compile")
+    logging.info("")

--- a/src/nile/core/install.py
+++ b/src/nile/core/install.py
@@ -1,12 +1,13 @@
 """Command to install a specific version of Cairo."""
+import logging
 import subprocess
 import sys
 
 
 def install():
     """Install Cairo package with the given tag."""
-    print("🗄  Installing Cairo")
+    logging.info("🗄  Installing Cairo")
     subprocess.check_call(
         [sys.executable, "-m", "pip", "install", "cairo-lang", "starknet-devnet"]
     )
-    print("✨  Cairo successfully installed!")
+    logging.info("✨  Cairo successfully installed!")

--- a/src/nile/core/install.py
+++ b/src/nile/core/install.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 
-def install_command():
+def install():
     """Install Cairo package with the given tag."""
     print("🗄  Installing Cairo")
     subprocess.check_call(

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -4,7 +4,7 @@ import json
 from nile.common import NODE_FILENAME
 
 
-def node_command(host="localhost", port=5000):
+def node(host="localhost", port=5000):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -1,6 +1,7 @@
 """Command to start StarkNet local network."""
-import subprocess
 import json
+import subprocess
+
 from nile.common import NODE_FILENAME
 
 

--- a/src/nile/core/run.py
+++ b/src/nile/core/run.py
@@ -1,0 +1,11 @@
+"""Command to clean artifacts from workspace."""
+from importlib.machinery import SourceFileLoader
+
+from nile.nre import NileRuntimeEnvironment
+
+
+def run(path, network):
+    """Run nile scripts passing on the NRE object."""
+    script = SourceFileLoader("script", path).load_module()
+    nre = NileRuntimeEnvironment(network)
+    script.run(nre)

--- a/src/nile/core/run.py
+++ b/src/nile/core/run.py
@@ -1,4 +1,5 @@
 """Command to clean artifacts from workspace."""
+import logging
 from importlib.machinery import SourceFileLoader
 
 from nile.nre import NileRuntimeEnvironment
@@ -6,6 +7,8 @@ from nile.nre import NileRuntimeEnvironment
 
 def run(path, network):
     """Run nile scripts passing on the NRE object."""
+    logger = logging.getLogger()
+    logger.disabled = True
     script = SourceFileLoader("script", path).load_module()
     nre = NileRuntimeEnvironment(network)
     script.run(nre)

--- a/src/nile/core/run.py
+++ b/src/nile/core/run.py
@@ -1,4 +1,4 @@
-"""Command to clean artifacts from workspace."""
+"""Command to run Nile scripts."""
 import logging
 from importlib.machinery import SourceFileLoader
 

--- a/src/nile/core/test.py
+++ b/src/nile/core/test.py
@@ -4,12 +4,12 @@ import asyncio
 from nile.common import CONTRACTS_DIRECTORY, get_all_contracts
 
 
-def test_command(contracts):
+def test(contracts):
     """Compile and run all provided Cairo tests."""
-    asyncio.run(_test_command(contracts))
+    asyncio.run(_test(contracts))
 
 
-async def _test_command(contracts):
+async def _test(contracts):
     if len(contracts) == 0:
         print(
             f"🤖 Running all test Cairo contracts in the {CONTRACTS_DIRECTORY} directory"

--- a/src/nile/core/version.py
+++ b/src/nile/core/version.py
@@ -2,6 +2,6 @@
 from nile import __version__ as nile_version
 
 
-def version_command():
+def version():
     """Print Nile version."""
     print(nile_version)

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -1,4 +1,5 @@
 """nile common module."""
+import logging
 import os
 
 from nile.common import DEPLOYMENTS_FILENAME
@@ -14,9 +15,9 @@ def register(address, abi, network, alias):
 
     with open(file, "a") as fp:
         if alias is not None:
-            print(f"📦 Registering deployment as {alias} in {file}")
+            logging.info(f"📦 Registering deployment as {alias} in {file}")
         else:
-            print(f"📦 Registering {address} in {file}")
+            logging.info(f"📦 Registering {address} in {file}")
 
         fp.write(f"{address}:{abi}")
         if alias is not None:

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -1,0 +1,33 @@
+"""nile runtime environment."""
+from nile import deployments
+from nile.core.call_or_invoke import call_or_invoke
+from nile.core.compile import compile
+from nile.core.deploy import deploy
+
+
+class NileRuntimeEnvironment:
+    """The NileRuntimeEnvironment exposes Nile functionality when running a script."""
+
+    def __init__(self, network="localhost"):
+        """Construct NRE object."""
+        self.network = network
+
+    def compile(self, contracts):
+        """Compile a list of contracts."""
+        return compile(contracts)
+
+    def deploy(self, contract, arguments, alias, overriding_path=None):
+        """Deploy a smart contract."""
+        return deploy(contract, arguments, self.network, alias, overriding_path)
+
+    def call(self, contract, method, params):
+        """Call a view function in a smart contract."""
+        return call_or_invoke(contract, "call", method, params, self.network)
+
+    def invoke(self, contract, method, params):
+        """Invoke a mutable function in a smart contract."""
+        return call_or_invoke(contract, "invoke", method, params, self.network)
+
+    def get_deployment(self, contract):
+        """Get a deployment by its identifier (address or alias)."""
+        return next(deployments.load(contract, self.network))

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -16,15 +16,15 @@ class NileRuntimeEnvironment:
         """Compile a list of contracts."""
         return compile(contracts)
 
-    def deploy(self, contract, arguments=[], alias=None, overriding_path=None):
+    def deploy(self, contract, arguments=None, alias=None, overriding_path=None):
         """Deploy a smart contract."""
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
-    def call(self, contract, method, params=[]):
+    def call(self, contract, method, params=None):
         """Call a view function in a smart contract."""
         return call_or_invoke(contract, "call", method, params, self.network)
 
-    def invoke(self, contract, method, params=[]):
+    def invoke(self, contract, method, params=None):
         """Invoke a mutable function in a smart contract."""
         return call_or_invoke(contract, "invoke", method, params, self.network)
 

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -16,15 +16,15 @@ class NileRuntimeEnvironment:
         """Compile a list of contracts."""
         return compile(contracts)
 
-    def deploy(self, contract, arguments, alias, overriding_path=None):
+    def deploy(self, contract, arguments=[], alias=None, overriding_path=None):
         """Deploy a smart contract."""
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
-    def call(self, contract, method, params):
+    def call(self, contract, method, params=[]):
         """Call a view function in a smart contract."""
         return call_or_invoke(contract, "call", method, params, self.network)
 
-    def invoke(self, contract, method, params):
+    def invoke(self, contract, method, params=[]):
         """Invoke a mutable function in a smart contract."""
         return call_or_invoke(contract, "invoke", method, params, self.network)
 

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nile.commands.clean import clean_command
+from nile.core.clean import clean
 from nile.common import (
     ACCOUNTS_FILENAME,
     BUILD_DIRECTORY,
@@ -18,10 +18,10 @@ def tmp_working_dir(monkeypatch, tmp_path):
     return tmp_path
 
 
-@patch("nile.commands.clean.shutil.rmtree")
-@patch("nile.commands.clean.os.remove")
-def test_clean_command_already_clean(mock_os_remove, mock_shutil_rmtree):
-    clean_command()
+@patch("nile.core.clean.shutil.rmtree")
+@patch("nile.core.clean.os.remove")
+def test_clean_already_clean(mock_os_remove, mock_shutil_rmtree):
+    clean()
     mock_os_remove.assert_not_called()
     mock_shutil_rmtree.assert_not_called()
 
@@ -33,19 +33,19 @@ def test_clean_command_already_clean(mock_os_remove, mock_shutil_rmtree):
         f"localhost.{DEPLOYMENTS_FILENAME}",
     ],
 )
-@patch("nile.commands.clean.shutil.rmtree")
-@patch("nile.commands.clean.os.remove")
-def test_clean_command_clean_files(mock_os_remove, mock_shutil_rmtree, fname):
+@patch("nile.core.clean.shutil.rmtree")
+@patch("nile.core.clean.os.remove")
+def test_clean_clean_files(mock_os_remove, mock_shutil_rmtree, fname):
     Path(fname).touch()
-    clean_command()
+    clean()
     mock_os_remove.assert_called_once_with(fname)
     mock_shutil_rmtree.assert_not_called()
 
 
-@patch("nile.commands.clean.shutil.rmtree")
-@patch("nile.commands.clean.os.remove")
-def test_clean_command_clean_build_dir(mock_os_remove, mock_shutil_rmtree):
+@patch("nile.core.clean.shutil.rmtree")
+@patch("nile.core.clean.os.remove")
+def test_clean_clean_build_dir(mock_os_remove, mock_shutil_rmtree):
     Path(BUILD_DIRECTORY).mkdir()
-    clean_command()
+    clean()
     mock_os_remove.assert_not_called()
     mock_shutil_rmtree.assert_called_once_with(BUILD_DIRECTORY)

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -4,12 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
+from nile.common import ACCOUNTS_FILENAME, BUILD_DIRECTORY, DEPLOYMENTS_FILENAME
 from nile.core.clean import clean
-from nile.common import (
-    ACCOUNTS_FILENAME,
-    BUILD_DIRECTORY,
-    DEPLOYMENTS_FILENAME,
-)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -3,6 +3,8 @@ Tests for compile command.
 
 Only unit tests for now. No contracts are actually compiled.
 """
+
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -50,14 +52,17 @@ def test_compile__compile_contract_called(mock__compile_contract):
 
 
 @patch("nile.core.compile._compile_contract")
-def test_compile_failure_feedback(mock__compile_contract, capsys):
+def test_compile_failure_feedback(mock__compile_contract, caplog):
+    # make logs visible to test
+    logging.getLogger().setLevel(logging.INFO)
+
     mock__compile_contract.side_effect = [0]
     compile([CONTRACT])
-    assert "Done" in capsys.readouterr().out
+    assert "Done" in caplog.text
 
     mock__compile_contract.side_effect = [1]
     compile([CONTRACT])
-    assert "Failed" in capsys.readouterr().out
+    assert "Failed" in caplog.text
 
 
 def test__compile_contract(mock_subprocess):

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from nile.common import ABIS_DIRECTORY, CONTRACTS_DIRECTORY
-from nile.commands.compile import _compile_contract, compile_command
+from nile.core.compile import _compile_contract, compile
 
 CONTRACT = "foo.cairo"
 
@@ -23,40 +23,40 @@ def tmp_working_dir(monkeypatch, tmp_path):
 # shell commands.
 @pytest.fixture(autouse=True)
 def mock_subprocess():
-    with patch("nile.commands.compile.subprocess") as mock_subprocess:
+    with patch("nile.core.compile.subprocess") as mock_subprocess:
         yield mock_subprocess
 
 
-def test_compile_command_create_abis_directory(tmp_working_dir):
+def test_compile_create_abis_directory(tmp_working_dir):
     assert not (tmp_working_dir / ABIS_DIRECTORY).exists()
-    compile_command([])
+    compile([])
     assert (tmp_working_dir / ABIS_DIRECTORY).exists()
 
 
-@patch("nile.commands.compile.get_all_contracts")
-def test_compile_command_get_all_contracts_called(mock_get_all_contracts):
-    compile_command([])
+@patch("nile.core.compile.get_all_contracts")
+def test_compile_get_all_contracts_called(mock_get_all_contracts):
+    compile([])
     mock_get_all_contracts.assert_called_once()
     mock_get_all_contracts.reset_mock()
 
-    compile_command([CONTRACT])
+    compile([CONTRACT])
     mock_get_all_contracts.assert_not_called()
 
 
-@patch("nile.commands.compile._compile_contract")
-def test_compile_command__compile_contract_called(mock__compile_contract):
-    compile_command([CONTRACT])
+@patch("nile.core.compile._compile_contract")
+def test_compile__compile_contract_called(mock__compile_contract):
+    compile([CONTRACT])
     mock__compile_contract.assert_called_once_with(CONTRACT)
 
 
-@patch("nile.commands.compile._compile_contract")
-def test_compile_command_failure_feedback(mock__compile_contract, capsys):
+@patch("nile.core.compile._compile_contract")
+def test_compile_failure_feedback(mock__compile_contract, capsys):
     mock__compile_contract.side_effect = [0]
-    compile_command([CONTRACT])
+    compile([CONTRACT])
     assert "Done" in capsys.readouterr().out
 
     mock__compile_contract.side_effect = [1]
-    compile_command([CONTRACT])
+    compile([CONTRACT])
     assert "Failed" in capsys.readouterr().out
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,27 +1,26 @@
 """Tests for cli.py."""
+import json
 import shutil
 import sys
-import json
-from pathlib import Path
 from multiprocessing import Process
-from threading import Timer
-from os import kill, getpid
+from os import getpid, kill
+from pathlib import Path
 from signal import SIGINT
-from urllib.request import urlopen
-from urllib.error import URLError
-
+from threading import Timer
 from time import sleep
+from urllib.error import URLError
+from urllib.request import urlopen
 
 import pytest
 from click.testing import CliRunner
 
+from nile.cli import cli
 from nile.common import (
     ABIS_DIRECTORY,
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
     NODE_FILENAME,
 )
-from nile.cli import cli
 
 RESOURCES_DIR = Path(__file__).parent / "resources"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for main.py."""
+"""Tests for cli.py."""
 import shutil
 import sys
 import json
@@ -21,7 +21,7 @@ from nile.common import (
     CONTRACTS_DIRECTORY,
     NODE_FILENAME,
 )
-from nile.main import cli
+from nile.cli import cli
 
 RESOURCES_DIR = Path(__file__).parent / "resources"
 


### PR DESCRIPTION
Solves #29 


- [x] Replaces `print` with `logger` to allow silent execution (scripting API shouldn't write to `stdout`)
- [x] Renames `commands` to `core` to signal its now common lib for CLI commands and scripting API as well
- [x] Add `nile run` script to inject a stateful Nile's runtime environment object (managing `network` and whatnot for the user)


You can execute the `run(nre)` function of a script with `nile run path/to/script.py`

```python
def run(nre):
    address, abi = nre.deploy("contract", alias="my_contract")
    print(abi, address)
```