### PR TITLE
Refactor account module and expose it through NRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,14 @@ A few things to notice here:
 4. By default Nile works on local, but you can use the `--network` parameter to interact with `mainnet`, `goerli`, and the default `localhost`.
 
 ### `setup`
+Deploy an Account associated with a given private key.
+
+To avoid accidentally leaking private keys, this command takes an alias instead of the actual private key. This alias is associated with an environmental variable of the same name, whose value is the actual private key.
+
 You can find an exemple `.env` file in `example.env`. These are private keys only to be used for testing and never in production.
 
 ```sh
-nile setup PKEY1
+nile setup <private_key_alias>
 
 🚀 Deploying Account
 🌕 artifacts/Account.json successfully deployed to 0x07db6b52c8ab888183277bc6411c400136fe566c0eebfb96fffa559b2e60e794
@@ -104,34 +108,19 @@ Transaction hash: 0x17
 
 A few things to notice here:
 
-1. `nile setup <env_var>` looks for an environement variable with the same name whose value is a private key
-2. This created a `localhost.accounts.json` file storing all data related to accounts management
-
-### `raw-execute`
-Execute a transaction through the `Account` associated with the private key used. The syntax is:
-
-```sh
-nile raw-execute <env_signer> <contract_address> <contract_method> <args>
-```
-
-```sh
-nile raw-execute PKEY1 0x0342e...4de4e0 transfer_ownership 0x07db6...60e794
-
-Invoke transaction was sent.
-Contract address: 0x03420417e09260947e3412d48952858a376f2d3ddde4e49f5981a2e41f4de4e0
-Transaction hash: 0x1c
-```
+1. `nile setup <private_key_alias>` looks for an environement variable with the name of the private key alias
+2. This creates a `localhost.accounts.json` file storing all data related to accounts management
 
 ### `send`
-Acts like `raw-execute` with the exception you can use it like you would use `nile invoke`.
-Execute a transaction through the `Account` associated with the private key used. The syntax is:
+Execute a transaction through the `Account` associated with the private key provided. The syntax is:
 
 ```sh
-nile send <env_signer> <contract_identifier> <contract_method> [PARAM_1, PARAM2...]
+nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...]
 ```
 
+For example:
 ```sh
-nile send PKEY1 ownable0 transfer_ownership 0x07db6...60e794
+nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794
 
 Invoke transaction was sent.
 Contract address: 0x07db6b52c8ab888183277bc6411c400136fe566c0eebfb96fffa559b2e60e794
@@ -142,7 +131,7 @@ Transaction hash: 0x1c
 Using `call` and `invoke`, we can perform read and write operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
 
 ```
-nile <command> <contract_identifier> <contract_method> [PARAM_1, PARAM2...]
+nile <command> <contract_identifier> <method> [PARAM_1, PARAM2...]
 ```
 
 Where `<command>` is either `call` or `invoke` and `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.

--- a/src/nile/accounts.py
+++ b/src/nile/accounts.py
@@ -21,8 +21,8 @@ def register(pubkey, address, index, network):
 
 def exists(pubkey, network):
     """Return whether an account exists or not."""
-    foo = next(load(pubkey, network), None)
-    return foo is not None
+    account = next(load(pubkey, network), None)
+    return account is not None
 
 
 def load(pubkey, network):

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -59,7 +59,7 @@ def deploy(artifact, arguments, network, alias):
 @click.argument("signer", nargs=1)
 @click.option("--network", default="localhost")
 def setup(signer, network):
-    """Do setup an Account contract."""
+    """Set up an Account contract."""
     Account(signer, network)
 
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -4,7 +4,7 @@ import logging
 
 import click
 
-from nile.core.account import account_raw_execute, account_send, account_setup
+from nile.core.account import Account
 from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
@@ -57,30 +57,22 @@ def deploy(artifact, arguments, network, alias):
 
 @cli.command()
 @click.argument("signer", nargs=1)
+@click.option("--network", default="localhost")
+def setup(signer, network):
+    """Do setup an Account contract."""
+    Account(signer, network)
+
+
+@cli.command()
+@click.argument("signer", nargs=1)
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
 @click.option("--network", default="localhost")
 def send(signer, contract_name, method, params, network):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
-    account_send(signer, contract_name, method, params, network)
-
-
-@cli.command(name="raw-execute")
-@click.argument("signer", nargs=1)
-@click.argument("params", nargs=-1)
-@click.option("--network", default="localhost")
-def raw_execute(signer, params, network):
-    """Invoke a contract through an Account."""
-    account_raw_execute(signer, params, network)
-
-
-@cli.command()
-@click.argument("signer", nargs=1)
-@click.option("--network", default="localhost")
-def setup(signer, network):
-    """Do setup an Account contract."""
-    account_setup(signer, network)
+    account = Account(signer, network)
+    account.send(contract_name, method, params)
 
 
 @cli.command()

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -12,69 +12,87 @@ from nile.signer import Signer
 load_dotenv()
 
 
-def account_setup(signer, network):
-    """Deploy an Account contract for the given private key."""
-    signer = Signer(int(os.environ[signer]), network)
-    if accounts.exists(str(signer.public_key), network):
-        signer_data = next(accounts.load(str(signer.public_key), network))
-        signer.account = signer_data["address"]
-        signer.index = signer_data["index"]
-    else:  # doesn't exist, have to deploy
-        signer.index = accounts.current_index(network)
-        pt = os.path.dirname(os.path.realpath(__file__)).replace("/commands", "")
+class Account:
+    """Account contract abstraction."""
+
+    def __init__(self, signer, network):
+        """Get or deploy an Account contract for the given private key."""
+        self.signer = Signer(int(os.environ[signer]))
+        self.network = network
+
+        if accounts.exists(str(self.signer.public_key), network):
+            signer_data = next(accounts.load(str(self.signer.public_key), network))
+            self.address = signer_data["address"]
+            self.index = signer_data["index"]
+        else:
+            address, index = self.deploy()
+            self.address = address
+            self.index = index
+
+    def deploy(self):
+        """Deploy an Account contract for the given private key."""
+        index = accounts.current_index(self.network)
+        pt = os.path.dirname(os.path.realpath(__file__)).replace("/core", "")
         overriding_path = (f"{pt}/artifacts", f"{pt}/artifacts/abis")
-        deploy(
+
+        address, _ = deploy(
             "Account",
-            [str(signer.public_key)],
-            network,
-            f"account-{signer.index}",
+            [str(self.signer.public_key)],
+            self.network,
+            f"account-{index}",
             overriding_path,
         )
-        address, _ = next(deployments.load(f"account-{signer.index}", network))
-        signer.account = address
-        accounts.register(signer.public_key, address, signer.index, network)
 
-    return signer
+        accounts.register(self.signer.public_key, address, index, self.network)
 
+        return address, index
 
-def account_send(signer, contract, method, params, network):
-    """Sugared call to a contract passing by an Account contract."""
-    address, abi = next(deployments.load(contract, network))
-    concatened_params = [address, method] + list(params)
-    return account_raw_execute(signer, concatened_params, network)
+    def send(self, to, method, calldata):
+        """Execute a tx going through an Account contract."""
+        target_address, _ = next(deployments.load(to, self.network)) or to
+        params = [target_address, method] + list(calldata)
+        _, abi = next(deployments.load(f"account-{self.index}", self.network))
 
+        command = [
+            "starknet",
+            "invoke",
+            "--address",
+            self.address,
+            "--abi",
+            abi,
+            "--function",
+            "execute",
+        ]
 
-def account_raw_execute(signer, params, network):
-    """Execute a tx going through an Account contract."""
-    # params are : to, selector_name, calldata
-    signer = account_setup(signer, network)
+        if self.network == "mainnet":
+            os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
+        elif self.network == "goerli":
+            os.environ["STARKNET_NETWORK"] = "alpha-goerli"
+        else:
+            gateway_prefix = "feeder_gateway" if type == "call" else "gateway"
+            command.append(f"--{gateway_prefix}_url={GATEWAYS.get(self.network)}")
 
-    _, abi = next(deployments.load(f"account-{signer.index}", network))
+        if len(params) > 0:
+            command.append("--inputs")
+            nonce = self.get_nonce()
+            ingested_inputs = self.signer.build_transaction(
+                sender=self.address,
+                to=params[0],
+                selector=params[1],
+                calldata=params[2:],
+                nonce=nonce,
+            )
+            command.extend([str(param) for param in ingested_inputs[0]])
+            command.append("--signature")
+            command.extend([str(sig_part) for sig_part in ingested_inputs[1]])
 
-    command = [
-        "starknet",
-        "invoke",
-        "--address",
-        signer.account,
-        "--abi",
-        abi,
-        "--function",
-        "execute",
-    ]
+        subprocess.check_call(command)
 
-    if network == "mainnet":
-        os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
-    elif network == "goerli":
-        os.environ["STARKNET_NETWORK"] = "alpha-goerli"
-    else:
-        gateway_prefix = "feeder_gateway" if type == "call" else "gateway"
-        command.append(f"--{gateway_prefix}_url={GATEWAYS.get(network)}")
-
-    if len(params) > 0:
-        command.append("--inputs")
-        ingested_inputs = signer.get_inputs(params[0], params[1], params[2:])
-        command.extend([str(param) for param in ingested_inputs[0]])
-        command.append("--signature")
-        command.extend([str(sig_part) for sig_part in ingested_inputs[1]])
-
-    subprocess.check_call(command)
+    def get_nonce(self):
+        """Get the nonce for the next transaction."""
+        nonce = subprocess.check_output(
+            f"nile call account-{self.index} get_nonce --network {self.network}",
+            shell=True,
+            encoding="utf-8",
+        )
+        return int(nonce)

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -1,5 +1,6 @@
 """nile runtime environment."""
 from nile import deployments
+from nile.core.account import Account
 from nile.core.call_or_invoke import call_or_invoke
 from nile.core.compile import compile
 from nile.core.deploy import deploy
@@ -31,3 +32,7 @@ class NileRuntimeEnvironment:
     def get_deployment(self, contract):
         """Get a deployment by its identifier (address or alias)."""
         return next(deployments.load(contract, self.network))
+
+    def get_or_deploy_account(self, signer):
+        """Get or deploy an Account contract."""
+        return Account(signer, self.network)

--- a/src/nile/signer.py
+++ b/src/nile/signer.py
@@ -1,6 +1,4 @@
 """Utility for sending signed transactions to an Account on Starknet."""
-import subprocess
-
 try:
     from starkware.cairo.common.hash_state import compute_hash_on_elements
     from starkware.crypto.signature.signature import private_to_stark_key, sign
@@ -14,36 +12,23 @@ except ImportError:
 class Signer:
     """Utility for sending signed transactions to an Account on Starknet."""
 
-    def __init__(self, private_key, network="localhost"):
+    def __init__(self, private_key):
         """Construct a Signer object. Takes a private key."""
         if not starkware_found:
             raise Exception("starkware module not found")
         self.private_key = private_key
         self.public_key = private_to_stark_key(private_key)
-        self.account = None
-        self.index = 0
-        self.network = network
 
     def sign(self, message_hash):
         """Sign a message hash."""
         return sign(msg_hash=message_hash, priv_key=self.private_key)
 
-    def get_nonce(self):
-        """Get the nonce for the next transaction."""
-        nonce = subprocess.check_output(
-            f"nile call account-{self.index} get_nonce --network {self.network}",
-            shell=True,
-            encoding="utf-8",
-        )
-        return int(nonce)
-
-    def get_inputs(self, to, selector_name, calldata):
+    def build_transaction(self, sender, to, selector, calldata, nonce):
         """Get the inputs for the next transaction in a CLI context."""
-        nonce = self.get_nonce()
-        selector = get_selector_from_name(selector_name)
+        selector = get_selector_from_name(selector)
         ingested_calldata = [int(arg, 16) for arg in calldata]
         message_hash = hash_message(
-            int(self.account, 16), int(to, 16), selector, ingested_calldata, nonce
+            int(sender, 16), int(to, 16), selector, ingested_calldata, nonce
         )
         sig_r, sig_s = self.sign(message_hash)
         return (


### PR DESCRIPTION
* Refactor `account.py` and `signer.py`, created the class `Account` and redistributed responsibilities among modules
* Expose `Account` through NRE for scripting
* Remove `raw-execute` to simplify interface and docs