### PR TITLE
Remove no longer needed %builtins directive

### DIFF
--- a/src/nile/base_project/contracts/contract.cairo
+++ b/src/nile/base_project/contracts/contract.cairo
@@ -1,7 +1,5 @@
-# Declare this file as a StarkNet contract and set the required
-# builtins.
+# Declare this file as a StarkNet contract.
 %lang starknet
-%builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
@@ -12,9 +10,8 @@ end
 
 # Increases the balance by the given amount.
 @external
-func increase_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount : felt):
+func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        amount : felt):
     let (res) = balance.read()
     balance.write(res + amount)
     return ()
@@ -22,9 +19,8 @@ end
 
 # Returns the current balance.
 @view
-func get_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res : felt):
+func get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
     let (res) = balance.read()
     return (res)
 end

--- a/tests/resources/contracts/contract.cairo
+++ b/tests/resources/contracts/contract.cairo
@@ -1,7 +1,5 @@
-# Declare this file as a StarkNet contract and set the required
-# builtins.
+# Declare this file as a StarkNet contract.
 %lang starknet
-%builtins pedersen range_check
 
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
@@ -12,9 +10,8 @@ end
 
 # Increases the balance by the given amount.
 @external
-func increase_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}(amount : felt):
+func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        amount : felt):
     let (res) = balance.read()
     balance.write(res + amount)
     return ()
@@ -22,9 +19,8 @@ end
 
 # Returns the current balance.
 @view
-func get_balance{
-        syscall_ptr : felt*, pedersen_ptr : HashBuiltin*,
-        range_check_ptr}() -> (res : felt):
+func get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
     let (res) = balance.read()
     return (res)
 end


### PR DESCRIPTION
Didn't see this housekeeping item in an open PR so felt like low hanging fruit :)

Feel free to close if already planned in another branch not visible here.

The other changes are a result of running the standard `cairo-format` on save. Though, I can revert those lines if this project is deliberately not using `cairo-format`