### PR TITLE
feat(cli): improved --network option

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -18,6 +18,27 @@ from nile.core.version import version as version_command
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
+NETWORKS = ("localhost", "goerli", "mainnet")
+
+network_option = lambda f: click.option(  # noqa: E731
+    "--network",
+    envvar="STARKNET_NETWORK",
+    default="localhost",
+    help=f"Select network, one of {NETWORKS}",
+    callback=_validate_network,
+)(f)
+
+
+def _validate_network(_ctx, _param, value):
+    # normalize goerli
+    if "goerli" in value or "testnet" in value:
+        return "goerli"
+    # check if value is accepted
+    if value in NETWORKS:
+        return value
+    # raise if value is invalid
+    raise click.BadParameter(f"'{value}'. Use one of {NETWORKS}")
+
 
 @click.group()
 def cli():
@@ -39,7 +60,7 @@ def install():
 
 @cli.command()
 @click.argument("path", nargs=1)
-@click.option("--network", default="localhost")
+@network_option
 def run(path, network):
     """Run Nile scripts with NileRuntimeEnvironment."""
     run_command(path, network)
@@ -48,7 +69,7 @@ def run(path, network):
 @cli.command()
 @click.argument("artifact", nargs=1)
 @click.argument("arguments", nargs=-1)
-@click.option("--network", default="localhost")
+@network_option
 @click.option("--alias")
 def deploy(artifact, arguments, network, alias):
     """Deploy StarkNet smart contract."""
@@ -57,7 +78,7 @@ def deploy(artifact, arguments, network, alias):
 
 @cli.command()
 @click.argument("signer", nargs=1)
-@click.option("--network", default="localhost")
+@network_option
 def setup(signer, network):
     """Set up an Account contract."""
     Account(signer, network)
@@ -68,7 +89,7 @@ def setup(signer, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.option("--network", default="localhost")
+@network_option
 def send(signer, contract_name, method, params, network):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
     account = Account(signer, network)
@@ -79,7 +100,7 @@ def send(signer, contract_name, method, params, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.option("--network", default="localhost")
+@network_option
 def invoke(contract_name, method, params, network):
     """Invoke functions of StarkNet smart contracts."""
     call_or_invoke_command(contract_name, "invoke", method, params, network)
@@ -89,7 +110,7 @@ def invoke(contract_name, method, params, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.option("--network", default="localhost")
+@network_option
 def call(contract_name, method, params, network):
     """Call functions of StarkNet smart contracts."""
     call_or_invoke_command(contract_name, "call", method, params, network)


### PR DESCRIPTION
This PR tries to improve the `--network` command line argument. It does the three following things:

1) The help message is better - it now enumerates the possible values for the argument (i.e. `localhost`, `goerli` or `mainnet`). The values are shown when using the `--help` arg or when passing in an invalid network name while using `--network`.

2) If takes the network value from the env var [`STARKNET_NETWORK`](https://starknet.io/docs/hello_starknet/account_setup.html#setting-up-the-network) which is what the `starknet` CLI tools use. If the env var is not set, it still defaults to `localhost`. If the env var is set, it can be overwritten by explicitly using the `--network` arg.

3) It normalizes the value of the `--network` argument so it's easier to switch toolchains (this one's highly subjective). Currently, there's no standardization in network naming. The Starknet CLI [uses](https://starknet.io/documentation/starknet-cli/) `alpha-goerli` and `alpha-mainnet`. Nile uses `goerli`, `mainnet` and `localhost`. Starknet.js [uses](https://github.com/0xs34n/starknet.js/blob/develop/src/provider/default.ts#L26) `mainnet-alpha` and `goerli-alpha`. Starknet.py [uses](https://github.com/software-mansion/starknet.py/blob/development/starknet_py/net/networks.py) `mainnet` and `testnet`. Might be that I'm the only one facing this issue, but sometimes I switch between projects/toolchains and it's a pain to try and remember what's the correct network name. In this PR I try to alleviate the pain a little by normalizing any string that has "goerli" or "testnet" in it to Nile's `goerli`. 

Please let me know what you think 😇