### PR TITLE
Add directory option to compile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Compile Cairo contracts. Compilation articacts are written into the `artifacts/`
 
 ```sh
 nile compile # compiles all contracts under contracts/
+nile compile --directory my_contracts # compiles all contracts under my_contracts/
 nile compile contracts/MyContract.cairo # compiles single contract
 ```
 Example output:

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -20,7 +20,8 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 NETWORKS = ("localhost", "goerli", "mainnet")
 
-network_option = lambda f: click.option(  # noqa: E731
+
+def network_option(f): return click.option(  # noqa: E731
     "--network",
     envvar="STARKNET_NETWORK",
     default="localhost",
@@ -136,7 +137,8 @@ def test(contracts):
 
 @cli.command()
 @click.argument("contracts", nargs=-1)
-def compile(contracts):
+@click.option("--directory")
+def compile(contracts, directory):
     """
     Compile cairo contracts.
 
@@ -149,7 +151,7 @@ def compile(contracts):
     $ compile.py contracts/foo.cairo contracts/bar.cairo
       Compiles foo.cairo and bar.cairo
     """
-    compile_command(contracts)
+    compile_command(contracts, directory)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -21,16 +21,19 @@ logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 NETWORKS = ("localhost", "goerli", "mainnet")
 
 
-def network_option(f): return click.option(  # noqa: E731
-    "--network",
-    envvar="STARKNET_NETWORK",
-    default="localhost",
-    help=f"Select network, one of {NETWORKS}",
-    callback=_validate_network,
-)(f)
+def network_option(f):
+    """Configure NETWORK option for the cli."""
+    return click.option(  # noqa: E731
+        "--network",
+        envvar="STARKNET_NETWORK",
+        default="localhost",
+        help=f"Select network, one of {NETWORKS}",
+        callback=_validate_network,
+    )(f)
 
 
 def _validate_network(_ctx, _param, value):
+    """Normalize network values."""
     # normalize goerli
     if "goerli" in value or "testnet" in value:
         return "goerli"

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -26,13 +26,13 @@ def _get_gateway():
 GATEWAYS = _get_gateway()
 
 
-def get_all_contracts(ext=None):
+def get_all_contracts(ext=None, directory=None):
     """Get all cairo contracts in the default contract directory."""
     if ext is None:
         ext = ".cairo"
 
     files = list()
-    for (dirpath, _, filenames) in os.walk(CONTRACTS_DIRECTORY):
+    for (dirpath, _, filenames) in os.walk(directory if directory else CONTRACTS_DIRECTORY):
         files += [
             os.path.join(dirpath, file) for file in filenames if file.endswith(ext)
         ]

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -32,7 +32,9 @@ def get_all_contracts(ext=None, directory=None):
         ext = ".cairo"
 
     files = list()
-    for (dirpath, _, filenames) in os.walk(directory if directory else CONTRACTS_DIRECTORY):
+    for (dirpath, _, filenames) in os.walk(
+        directory if directory else CONTRACTS_DIRECTORY
+    ):
         files += [
             os.path.join(dirpath, file) for file in filenames if file.endswith(ext)
         ]

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -11,9 +11,11 @@ from nile.common import (
 )
 
 
-def compile(contracts):
+def compile(contracts, directory=None):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
+
+    contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
     if not os.path.exists(ABIS_DIRECTORY):
         logging.info(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
@@ -23,11 +25,12 @@ def compile(contracts):
 
     if len(contracts) == 0:
         logging.info(
-            f"🤖 Compiling all Cairo contracts in the {CONTRACTS_DIRECTORY} directory"
+            f"🤖 Compiling all Cairo contracts in the {contracts_directory} directory"
         )
-        all_contracts = get_all_contracts()
+        all_contracts = get_all_contracts(directory=contracts_directory)
 
-    results = [_compile_contract(contract) for contract in all_contracts]
+    results = [_compile_contract(contract, contracts_directory)
+               for contract in all_contracts]
     failed_contracts = [c for (c, r) in zip(all_contracts, results) if r != 0]
     failures = len(failed_contracts)
 
@@ -42,14 +45,14 @@ def compile(contracts):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path):
+def _compile_contract(path, contracts_directory):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
 
     cmd = f"""
     starknet-compile {path} \
-        --cairo_path={CONTRACTS_DIRECTORY}
+        --cairo_path={contracts_directory}
         --output {BUILD_DIRECTORY}/{filename}.json \
         --abi {ABIS_DIRECTORY}/{filename}.json
     """

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -29,8 +29,9 @@ def compile(contracts, directory=None):
         )
         all_contracts = get_all_contracts(directory=contracts_directory)
 
-    results = [_compile_contract(contract, contracts_directory)
-               for contract in all_contracts]
+    results = [
+        _compile_contract(contract, contracts_directory) for contract in all_contracts
+    ]
     failed_contracts = [c for (c, r) in zip(all_contracts, results) if r != 0]
     failures = len(failed_contracts)
 
@@ -45,10 +46,11 @@ def compile(contracts, directory=None):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path, contracts_directory):
+def _compile_contract(path, directory=None):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
+    contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
     cmd = f"""
     starknet-compile {path} \

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -48,7 +48,7 @@ def test_compile_get_all_contracts_called(mock_get_all_contracts):
 @patch("nile.core.compile._compile_contract")
 def test_compile__compile_contract_called(mock__compile_contract):
     compile([CONTRACT])
-    mock__compile_contract.assert_called_once_with(CONTRACT)
+    mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY)
 
 
 @patch("nile.core.compile._compile_contract")


### PR DESCRIPTION
This feature allows projects like [OpenZeppelin Cairo Contracts](https://github.com/OpenZeppelin/cairo-contracts/pulls) to compile cairo contracts in custom directories, for example:

```sh
cairo-contracts git:(main) $ nile compile --directory openzeppelin
🤖 Compiling all Cairo contracts in the openzeppelin directory
🔨 Compiling openzeppelin/introspection/ERC165.cairo
🔨 Compiling openzeppelin/introspection/IERC165.cairo
🔨 Compiling openzeppelin/token/erc721/ERC721_Mintable_Burnable.cairo
🔨 Compiling openzeppelin/token/erc721/ERC721_Mintable_Pausable.cairo
🔨 Compiling openzeppelin/token/erc721/library.cairo
🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721_Metadata.cairo
🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721.cairo
🔨 Compiling openzeppelin/token/erc721/interfaces/IERC721_Receiver.cairo
🔨 Compiling openzeppelin/token/erc721/utils/ERC721_Holder.cairo
🔨 Compiling openzeppelin/token/erc20/ERC20_Mintable.cairo
🔨 Compiling openzeppelin/token/erc20/ERC20.cairo
🔨 Compiling openzeppelin/token/erc20/library.cairo
🔨 Compiling openzeppelin/token/erc20/ERC20_Pausable.cairo
🔨 Compiling openzeppelin/token/erc20/interfaces/IERC20.cairo
🔨 Compiling openzeppelin/token/erc721_enumerable/ERC721_Enumerable_Mintable_Burnable.cairo
🔨 Compiling openzeppelin/token/erc721_enumerable/library.cairo
🔨 Compiling openzeppelin/token/erc721_enumerable/interfaces/IERC721_Enumerable.cairo
🔨 Compiling openzeppelin/security/pausable.cairo
🔨 Compiling openzeppelin/security/safemath.cairo
🔨 Compiling openzeppelin/security/initializable.cairo
🔨 Compiling openzeppelin/access/ownable.cairo
🔨 Compiling openzeppelin/account/IAccount.cairo
🔨 Compiling openzeppelin/account/Account.cairo
🔨 Compiling openzeppelin/account/AddressRegistry.cairo
🔨 Compiling openzeppelin/utils/constants.cairo
✅ Done
```