### PR TITLE
Fix deployment issue with default gateway url

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -18,7 +18,7 @@ from nile.core.version import version as version_command
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
-NETWORKS = ("127.0.0.1", "goerli", "mainnet")
+NETWORKS = ("localhost", "goerli", "mainnet")
 
 
 def network_option(f):

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -18,7 +18,7 @@ from nile.core.version import version as version_command
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
-NETWORKS = ("localhost", "goerli", "mainnet")
+NETWORKS = ("127.0.0.1", "goerli", "mainnet")
 
 
 def network_option(f):
@@ -26,7 +26,7 @@ def network_option(f):
     return click.option(  # noqa: E731
         "--network",
         envvar="STARKNET_NETWORK",
-        default="localhost",
+        default="127.0.0.1",
         help=f"Select network, one of {NETWORKS}",
         callback=_validate_network,
     )(f)
@@ -164,7 +164,7 @@ def clean():
 
 
 @cli.command()
-@click.option("--host", default="localhost")
+@click.option("--host", default="127.0.0.1")
 @click.option("--port", default=5000)
 def node(host, port):
     """Start StarkNet local network.

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -20,7 +20,7 @@ def _get_gateway():
 
     except FileNotFoundError:
         with open(NODE_FILENAME, "w") as f:
-            f.write('{"localhost": "http://localhost:5000/"}')
+            f.write('{"localhost": "http://127.0.0.1:5000/"}')
 
 
 GATEWAYS = _get_gateway()

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -5,7 +5,7 @@ import subprocess
 from nile.common import NODE_FILENAME
 
 
-def node(host="localhost", port=5000):
+def node(host="127.0.0.1", port=5000):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,7 +105,7 @@ def test_compile(args, expected):
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], "http://localhost:5000/"),
+        ([], "http://127.0.0.1:5000/"),
         (["--host", "localhost", "--port", "5001"], "http://localhost:5001/"),
     ],
 )
@@ -119,7 +119,7 @@ def test_node(args, expected):
     seconds = 8
 
     if args == []:
-        host, port = "localhost", 5000
+        host, port = "127.0.0.1", 5000
     else:
         host, port = args[1], int(args[3])
 


### PR DESCRIPTION
This PR proposes to add `127.0.0.1` in favor of `localhost` as the default gateway url. The issue is explained below for posterity.

Deploying an account fails with a `BadRequest` error when, it appears, running MacOS. A suggested cause was that newer Macs use IPv6 which uses `::1/128` as its loopback network address as opposed to IPv4 which uses `127.0.0.1`. It seems, however, that this is not the entire cause. Turning off IPv6 and recloning the repo with a new venv still returned the `BadRequest` error. Further, it's confirmed that `localhost` was bound to `127.0.0.1` on my machine. I _was_ able to deploy an account with the default `localhost` while running Ubuntu. 

As proposed in #63, changing the default gateway url to `127.0.0.1` solves the deployment issue.

This PR also left the `localhost` nomenclature for aesthetics, but this can easily be changed if preferred.