### PR TITLE
Add cairo-compile & cairo-run method to nile

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -65,9 +65,10 @@ def install():
 @cli.command()
 @click.argument("path", nargs=1)
 @network_option
-def run(path, network):
+@click.option("--method")
+def run(path, network, method):
     """Run Nile scripts with NileRuntimeEnvironment."""
-    run_command(path, network)
+    run_command(path, network, method)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -19,7 +19,7 @@ from nile.core.version import version as version_command
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
 NETWORKS = ("localhost", "goerli", "mainnet")
-
+DEFAULT_COMPILE_METHOD = "starknet"
 
 def network_option(f):
     """Configure NETWORK option for the cli."""
@@ -141,7 +141,7 @@ def test(contracts):
 @cli.command()
 @click.argument("contracts", nargs=-1)
 @click.option("--directory")
-@click.option("--method", default="starknet")
+@click.option("--method", default=DEFAULT_COMPILE_METHOD)
 def compile(contracts, directory, method):
     """
     Compile cairo contracts.

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -141,7 +141,7 @@ def test(contracts):
 @cli.command()
 @click.argument("contracts", nargs=-1)
 @click.option("--directory")
-@click.option("--method")
+@click.option("--method", default="starknet")
 def compile(contracts, directory, method):
     """
     Compile cairo contracts.

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -141,12 +141,16 @@ def test(contracts):
 @cli.command()
 @click.argument("contracts", nargs=-1)
 @click.option("--directory")
-def compile(contracts, directory):
+@click.option("--method")
+def compile(contracts, directory, method):
     """
     Compile cairo contracts.
 
     $ compile.py
       Compiles all contracts in CONTRACTS_DIRECTORY
+
+    $ compile.py --method cairo
+      Compiles all contracts in CONTRACTS_DIRECTORY using cairo-compile (default: starknet-compile)
 
     $ compile.py contracts/MyContract.cairo
       Compiles MyContract.cairo
@@ -154,7 +158,7 @@ def compile(contracts, directory):
     $ compile.py contracts/foo.cairo contracts/bar.cairo
       Compiles foo.cairo and bar.cairo
     """
-    compile_command(contracts, directory)
+    compile_command(contracts, directory, method)
 
 
 @cli.command()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -10,6 +10,7 @@ DEPLOYMENTS_FILENAME = "deployments.txt"
 ACCOUNTS_FILENAME = "accounts.json"
 NODE_FILENAME = "node.json"
 
+DEFAULT_COMPILE_METHOD = "starknet"
 
 def _get_gateway():
     """Get the StarkNet node details."""

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -10,7 +10,8 @@ DEPLOYMENTS_FILENAME = "deployments.txt"
 ACCOUNTS_FILENAME = "accounts.json"
 NODE_FILENAME = "node.json"
 
-DEFAULT_COMPILE_METHOD = "starknet"
+STARKNET_COMPILE_METHOD = "starknet"
+CAIRO_COMPILE_METHOD = "cairo"
 
 def _get_gateway():
     """Get the StarkNet node details."""

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -11,7 +11,7 @@ from nile.common import (
 )
 
 
-def compile(contracts, directory=None):
+def compile(contracts, directory=None, method="starknet"):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
 
@@ -30,7 +30,7 @@ def compile(contracts, directory=None):
         all_contracts = get_all_contracts(directory=contracts_directory)
 
     results = [
-        _compile_contract(contract, contracts_directory) for contract in all_contracts
+        _compile_contract(contract, contracts_directory, method) for contract in all_contracts
     ]
     failed_contracts = [c for (c, r) in zip(all_contracts, results) if r != 0]
     failures = len(failed_contracts)
@@ -46,18 +46,26 @@ def compile(contracts, directory=None):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path, directory=None):
+def _compile_contract(path, directory=None, method="starknet"):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
     contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
-    cmd = f"""
-    starknet-compile {path} \
-        --cairo_path={contracts_directory}
-        --output {BUILD_DIRECTORY}/{filename}.json \
-        --abi {ABIS_DIRECTORY}/{filename}.json
-    """
+    if method == "starknet":
+        cmd = f"""
+        starknet-compile {path} \
+            --cairo_path={contracts_directory}
+            --output {BUILD_DIRECTORY}/{filename}.json \
+            --abi {ABIS_DIRECTORY}/{filename}.json
+        """
+    
+    elif method == "cairo":
+        cmd = f"""
+        cairo-compile {path} \
+            --cairo_path={contracts_directory}
+            --output {BUILD_DIRECTORY}/{filename}.json
+        """
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     process.communicate()
     return process.returncode

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -7,11 +7,12 @@ from nile.common import (
     ABIS_DIRECTORY,
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
+    DEFAULT_COMPILE_METHOD,
     get_all_contracts,
 )
 
 
-def compile(contracts, directory=None, method="starknet"):
+def compile(contracts, directory=None, method=DEFAULT_COMPILE_METHOD):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
 
@@ -46,13 +47,13 @@ def compile(contracts, directory=None, method="starknet"):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path, directory=None, method="starknet"):
+def _compile_contract(path, directory=None, method=DEFAULT_COMPILE_METHOD):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
     contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
-    if method == "starknet":
+    if method == DEFAULT_COMPILE_METHOD:
         cmd = f"""
         starknet-compile {path} \
             --cairo_path={contracts_directory}

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -7,12 +7,13 @@ from nile.common import (
     ABIS_DIRECTORY,
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
-    DEFAULT_COMPILE_METHOD,
+    STARKNET_COMPILE_METHOD,
+    CAIRO_COMPILE_METHOD,
     get_all_contracts,
 )
 
 
-def compile(contracts, directory=None, method=DEFAULT_COMPILE_METHOD):
+def compile(contracts, directory=None, method=STARKNET_COMPILE_METHOD):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
 
@@ -47,13 +48,13 @@ def compile(contracts, directory=None, method=DEFAULT_COMPILE_METHOD):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path, directory=None, method=DEFAULT_COMPILE_METHOD):
+def _compile_contract(path, directory=None, method=STARKNET_COMPILE_METHOD):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
     contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
-    if method == DEFAULT_COMPILE_METHOD:
+    if method == STARKNET_COMPILE_METHOD:
         cmd = f"""
         starknet-compile {path} \
             --cairo_path={contracts_directory}
@@ -61,7 +62,7 @@ def _compile_contract(path, directory=None, method=DEFAULT_COMPILE_METHOD):
             --abi {ABIS_DIRECTORY}/{filename}.json
         """
     
-    elif method == "cairo":
+    elif method == CAIRO_COMPILE_METHOD:
         cmd = f"""
         cairo-compile {path} \
             --cairo_path={contracts_directory}

--- a/src/nile/core/run.py
+++ b/src/nile/core/run.py
@@ -1,14 +1,33 @@
 """Command to run Nile scripts."""
 import logging
+import subprocess
 from importlib.machinery import SourceFileLoader
 
 from nile.nre import NileRuntimeEnvironment
 
 
-def run(path, network):
+def run(path, network, method):
     """Run nile scripts passing on the NRE object."""
+    if method == "cairo":
+        return _run_cairo(path)
+
     logger = logging.getLogger()
     logger.disabled = True
     script = SourceFileLoader("script", path).load_module()
     nre = NileRuntimeEnvironment(network)
     script.run(nre)
+
+
+def _run_cairo(path):
+    logging.info(f"🚀 Running Cairo program {path}")
+
+    cmd = f"""
+    cairo-run \
+        --program={path} \
+        --print_output --layout=small
+    """ 
+
+    process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+    out, err = process.communicate()
+    logging.info(out.decode("UTF-8"))
+    return process.returncode

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -52,6 +52,11 @@ def test_compile__compile_contract_called(mock__compile_contract):
     compile([CONTRACT])
     mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY, COMPILE_METHOD_STARKNET)
 
+@patch("nile.core.compile._compile_contract")
+def test_compile__compile_contract_cairo_called(mock__compile_contract):
+    compile([CONTRACT], method=COMPILE_METHOD_CAIRO)
+    mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY, COMPILE_METHOD_CAIRO)
+
 
 @patch("nile.core.compile._compile_contract")
 def test_compile_failure_feedback(mock__compile_contract, caplog):
@@ -85,6 +90,28 @@ def test__compile_contract(mock_subprocess):
             f"artifacts/{contract_name_root}.json",
             "--abi",
             f"artifacts/abis/{contract_name_root}.json",
+        ],
+        stdout=mock_subprocess.PIPE,
+    )
+    mock_process.communicate.assert_called_once()
+
+
+def test__compile_contract_cairo(mock_subprocess):
+    contract_name_root = "contract"
+    path = f"path/to/{contract_name_root}.cairo"
+
+    mock_process = Mock()
+    mock_subprocess.Popen.return_value = mock_process
+
+    _compile_contract(path, method=COMPILE_METHOD_CAIRO)
+
+    mock_subprocess.Popen.assert_called_once_with(
+        [
+            "cairo-compile",
+            path,
+            f"--cairo_path={CONTRACTS_DIRECTORY}",
+            "--output",
+            f"artifacts/{contract_name_root}.json",
         ],
         stdout=mock_subprocess.PIPE,
     )

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -14,6 +14,8 @@ from nile.core.compile import _compile_contract, compile
 
 CONTRACT = "foo.cairo"
 
+COMPILE_METHOD_STARKNET = "starknet"
+COMPILE_METHOD_CAIRO = "cairo"
 
 @pytest.fixture(autouse=True)
 def tmp_working_dir(monkeypatch, tmp_path):
@@ -48,7 +50,7 @@ def test_compile_get_all_contracts_called(mock_get_all_contracts):
 @patch("nile.core.compile._compile_contract")
 def test_compile__compile_contract_called(mock__compile_contract):
     compile([CONTRACT])
-    mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY)
+    mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY, COMPILE_METHOD_STARKNET)
 
 
 @patch("nile.core.compile._compile_contract")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,8 @@ from nile.common import (
     BUILD_DIRECTORY,
     CONTRACTS_DIRECTORY,
     NODE_FILENAME,
+    STARKNET_COMPILE_METHOD,
+    CAIRO_COMPILE_METHOD,
 )
 
 RESOURCES_DIR = Path(__file__).parent / "resources"
@@ -70,9 +72,10 @@ def test_clean():
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], {"contract_1.json", "contract_2.json"}),
+        ([], {"contract_1.json", "contract_2.json", "contract_3.json"}),
         (["contract_1.cairo"], {"contract_1.json"}),
         (["contract_2.cairo"], {"contract_2.json"}),
+        (["contract_3.cairo", "--method", CAIRO_COMPILE_METHOD], {"contract_3.json"}),
     ],
 )
 @pytest.mark.xfail(
@@ -88,6 +91,7 @@ def test_compile(args, expected):
 
     shutil.copyfile(contract_source, target_dir / "contract_1.cairo")
     shutil.copyfile(contract_source, target_dir / "contract_2.cairo")
+    shutil.copyfile(contract_source, target_dir / "contract_3.cairo")
 
     abi_dir = Path(ABIS_DIRECTORY)
     build_dir = Path(BUILD_DIRECTORY)
@@ -98,7 +102,9 @@ def test_compile(args, expected):
     result = CliRunner().invoke(cli, ["compile", *args])
     assert result.exit_code == 0
 
-    assert {f.name for f in abi_dir.glob("*.json")} == expected
+    if CAIRO_COMPILE_METHOD not in args:
+        assert {f.name for f in abi_dir.glob("*.json")} == expected
+
     assert {f.name for f in build_dir.glob("*.json")} == expected
 
 


### PR DESCRIPTION
#### Issues
The current ```nile compile``` command only supports ```starknet-compile``` method, this is not really convenient for those who would like to use ```cairo-compile``` method with nile.  

#### Improvement
I added the ```cairo-compile``` method to ```nile compile``` command, the usage will be:  
```bash
nile compile <contract> --method cairo
```
The default compile method is set to be ```starknet```, which is ```starknet-compile```. Unit tests have been added to ```tox```.

#### Update (2022-03-09)
```cairo-run``` is added to the branch, usage would be:  
```bash
nile run path/to/program.cairo --method cairo
```
#### TODO
- Unit tests have have not been added for ```cairo-run```.
- ```cairo-run``` is set as ```cairo-run --program={path} --print_output --layout=small``` for now