### PR TITLE
Add account compilation check

### DIFF
--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -58,6 +58,9 @@ def _compile_contract(path, directory=None):
         --output {BUILD_DIRECTORY}/{filename}.json \
         --abi {ABIS_DIRECTORY}/{filename}.json
     """
+    if "Account" in str(filename):
+        cmd = cmd + f"--account_contract"
+
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     process.communicate()
     return process.returncode

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -87,3 +87,28 @@ def test__compile_contract(mock_subprocess):
         stdout=mock_subprocess.PIPE,
     )
     mock_process.communicate.assert_called_once()
+
+
+def test__compile_account_contract(mock_subprocess):
+    contract_name_root = "Account"
+    path = f"path/to/{contract_name_root}.cairo"
+
+    mock_process = Mock()
+    mock_subprocess.Popen.return_value = mock_process
+
+    _compile_contract(path)
+
+    mock_subprocess.Popen.assert_called_once_with(
+        [
+            "starknet-compile",
+            path,
+            f"--cairo_path={CONTRACTS_DIRECTORY}",
+            "--output",
+            f"artifacts/{contract_name_root}.json",
+            "--abi",
+            f"artifacts/abis/{contract_name_root}.json",
+            f"--account_contract"
+        ],
+        stdout=mock_subprocess.PIPE,
+    )
+    mock_process.communicate.assert_called_once()


### PR DESCRIPTION
Cairo's 0.8.0 update requires that account contracts (with the external `__execute__` method) require an `--account_contract` flag to compile. This PR proposes to check for "Account" in the filename. In which case, the `--account_contract` flag will be included in the account compilation instruction. 

Note that this proposed change implies that all account contracts (again, with the exposed `__execute__` method) must have `Account` in its file name in order for Nile to correctly compile.