### PR TITLE
Add --disable-hint-validation flag to nile

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Compile Cairo contracts. Compilation artifacts are written into the `artifacts/`
 nile compile # compiles all contracts under contracts/
 nile compile --directory my_contracts # compiles all contracts under my_contracts/
 nile compile contracts/MyContract.cairo # compiles single contract
+nile compile contracts/MyContract.cairo --disable-hint-validation # compiles single contract with unwhitelisted hints
 ```
 
 As of cairo-lang v0.8.0, account contracts (contracts with the `__execute__` method) must be compiled with the `--account_contract` flag.

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -151,6 +151,7 @@ def test(contracts):
 
 @cli.command()
 @click.argument("contracts", nargs=-1)
+@click.option("--disable-hint-validation", is_flag=True)
 @click.option("--directory")
 @click.option("--account_contract", is_flag="True")
 def compile(contracts, directory, account_contract):

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -151,10 +151,10 @@ def test(contracts):
 
 @cli.command()
 @click.argument("contracts", nargs=-1)
-@click.option("--disable-hint-validation", is_flag=True)
 @click.option("--directory")
 @click.option("--account_contract", is_flag="True")
-def compile(contracts, directory, account_contract):
+@click.option("--disable-hint-validation", is_flag=True)
+def compile(contracts, directory, account_contract, disable_hint_validation):
     """
     Compile cairo contracts.
 
@@ -167,7 +167,7 @@ def compile(contracts, directory, account_contract):
     $ compile.py contracts/foo.cairo contracts/bar.cairo
       Compiles foo.cairo and bar.cairo
     """
-    compile_command(contracts, directory, account_contract)
+    compile_command(contracts, directory, account_contract, disable_hint_validation)
 
 
 @cli.command()

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -11,13 +11,13 @@ from nile.common import (
 )
 
 
-def compile(contracts, directory=None, account_contract=False):
+def compile(
+    contracts, directory=None, account_contract=False, disable_hint_validation=False
+):
     """Compile cairo contracts to default output directory."""
     # to do: automatically support subdirectories
 
     contracts_directory = directory if directory else CONTRACTS_DIRECTORY
-
-    hint_validation = "--disable_hint_validation" if disable_hint_validation else ""
 
     if not os.path.exists(ABIS_DIRECTORY):
         logging.info(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
@@ -32,7 +32,9 @@ def compile(contracts, directory=None, account_contract=False):
         all_contracts = get_all_contracts(directory=contracts_directory)
 
     results = [
-        _compile_contract(contract, contracts_directory, account_contract)
+        _compile_contract(
+            contract, contracts_directory, account_contract, disable_hint_validation
+        )
         for contract in all_contracts
     ]
     failed_contracts = [c for (c, r) in zip(all_contracts, results) if r != 0]
@@ -49,7 +51,9 @@ def compile(contracts, directory=None, account_contract=False):
             logging.info(f"   {contract}")
 
 
-def _compile_contract(path, directory=None, account_contract=False):
+def _compile_contract(
+    path, directory=None, account_contract=False, disable_hint_validation=False
+):
     base = os.path.basename(path)
     filename = os.path.splitext(base)[0]
     logging.info(f"🔨 Compiling {path}")
@@ -59,11 +63,14 @@ def _compile_contract(path, directory=None, account_contract=False):
     starknet-compile {path} \
         --cairo_path={contracts_directory}
         --output {BUILD_DIRECTORY}/{filename}.json \
-        --abi {ABIS_DIRECTORY}/{filename}.json {hint_validation}
+        --abi {ABIS_DIRECTORY}/{filename}.json
     """
 
     if account_contract:
         cmd = cmd + "--account_contract"
+
+    if disable_hint_validation:
+        cmd = cmd + "--disable_hint_validation"
 
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     process.communicate()

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -17,6 +17,8 @@ def compile(contracts, directory=None, account_contract=False):
 
     contracts_directory = directory if directory else CONTRACTS_DIRECTORY
 
+    hint_validation = "--disable_hint_validation" if disable_hint_validation else ""
+
     if not os.path.exists(ABIS_DIRECTORY):
         logging.info(f"📁 Creating {ABIS_DIRECTORY} to store compilation artifacts")
         os.makedirs(ABIS_DIRECTORY, exist_ok=True)
@@ -57,7 +59,7 @@ def _compile_contract(path, directory=None, account_contract=False):
     starknet-compile {path} \
         --cairo_path={contracts_directory}
         --output {BUILD_DIRECTORY}/{filename}.json \
-        --abi {ABIS_DIRECTORY}/{filename}.json
+        --abi {ABIS_DIRECTORY}/{filename}.json {hint_validation}
     """
 
     if account_contract:

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -112,3 +112,28 @@ def test__compile_account_contract(mock_subprocess):
         stdout=mock_subprocess.PIPE,
     )
     mock_process.communicate.assert_called_once()
+
+
+def test__compile_contract_without_hint_validation(mock_subprocess):
+    contract_name_root = "contract_with_unwhitelisted_hints"
+    path = f"path/to/{contract_name_root}.cairo"
+
+    mock_process = Mock()
+    mock_subprocess.Popen.return_value = mock_process
+
+    _compile_contract(path, disable_hint_validation=True)
+
+    mock_subprocess.Popen.assert_called_once_with(
+        [
+            "starknet-compile",
+            path,
+            f"--cairo_path={CONTRACTS_DIRECTORY}",
+            "--output",
+            f"artifacts/{contract_name_root}.json",
+            "--abi",
+            f"artifacts/abis/{contract_name_root}.json",
+            "--disable_hint_validation",
+        ],
+        stdout=mock_subprocess.PIPE,
+    )
+    mock_process.communicate.assert_called_once()

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -48,7 +48,9 @@ def test_compile_get_all_contracts_called(mock_get_all_contracts):
 @patch("nile.core.compile._compile_contract")
 def test_compile__compile_contract_called(mock__compile_contract):
     compile([CONTRACT])
-    mock__compile_contract.assert_called_once_with(CONTRACT, CONTRACTS_DIRECTORY, False)
+    mock__compile_contract.assert_called_once_with(
+        CONTRACT, CONTRACTS_DIRECTORY, False, False
+    )
 
 
 @patch("nile.core.compile._compile_contract")

--- a/tests/resources/contracts/contract_with_unwhitelisted_hints.cairo
+++ b/tests/resources/contracts/contract_with_unwhitelisted_hints.cairo
@@ -1,0 +1,27 @@
+# Declare this file as a StarkNet contract.
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+# Define a storage variable.
+@storage_var
+func balance() -> (res : felt):
+end
+
+# Increases the balance by the given amount.
+@external
+func increase_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        amount : felt):
+    let (res) = balance.read()
+    %{ print(f"{ids.res=}, {ids.amount=}") %}
+    balance.write(res + amount)
+    return ()
+end
+
+# Returns the current balance.
+@view
+func get_balance{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+        res : felt):
+    let (res) = balance.read()
+    return (res)
+end


### PR DESCRIPTION
This flag doesn't exist in nile so we it's impossible to compile smart-contracts with unwhitelisted hints such as print or other logging packages. Allowing them will significantly ease debugging