### PR TITLE
Fix werkzeug version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ passenv =
 extras =
     testing
 deps =
+    werkzeug==2.0.0
     starknet-devnet
 commands =
     pytest {posargs}


### PR DESCRIPTION
Fix [upstream dependency error](https://github.com/pallets/werkzeug/issues/2364) by downgrading it. Thanks to @franalgaba for [looking into it](https://github.com/OpenZeppelin/nile/pull/86#issuecomment-1084985907).