### PR TITLE
Test Account class and commands

### DIFF
--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -1,0 +1,73 @@
+"""Tests for account commands."""
+import pytest
+from unittest.mock import patch
+
+from nile.core.account import Account
+
+KEY = "TEST_KEY"
+NETWORK = "goerli"
+MOCK_ADDRESS = "0x123"
+MOCK_INDEX = 0
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+    
+
+@patch("nile.core.account.Account.deploy")
+def test_account_init(mock_deploy):
+    mock_deploy.return_value = MOCK_ADDRESS, MOCK_INDEX
+    account = Account(KEY, NETWORK)
+    assert account.address == MOCK_ADDRESS
+    assert account.index == MOCK_INDEX
+    mock_deploy.assert_called_once()
+
+
+def test_account_init_account_exists():
+    account = Account(KEY, NETWORK)
+    account.deploy()
+    account2 = Account(KEY, NETWORK)
+    # Check addresses don't match
+    assert account.address != account2.address
+    # Check indexing
+    assert account.index == 0
+    assert account2.index == 1    
+
+
+@patch("nile.core.account.deploy")
+def test_deploy_accounts_register(mock_deploy):
+    mock_deploy.return_value = MOCK_ADDRESS, MOCK_INDEX
+
+    with patch("nile.core.account.accounts.register") as mock_register:
+        account = Account(KEY, NETWORK)
+
+        mock_register.assert_called_once_with(
+            account.signer.public_key,
+            MOCK_ADDRESS,
+            MOCK_INDEX,
+            NETWORK
+        )
+
+@patch("nile.core.account.Account")
+def test_send_sign_transaction(mock_account):
+    account = Account(KEY, NETWORK)
+    addr, _ = account.deploy()
+    # Instead of creating and populating a tmp .txt file, this uses the
+    # deployed account address as the target
+    args = [addr, "method", [1, 2, 3]]
+
+    with patch("nile.core.account.call_or_invoke") as mock_call:
+        account.send(*args)
+        assert mock_call.call_count == 2
+
+        # Check 'get_nonce' call
+        mock_call.assert_any_call(
+            account.address, 'call', 'get_nonce', [], 'goerli'
+        )
+
+        mock_account = mock_call.call_args_list
+        print(mock_account)
+        
+ 

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -27,7 +27,7 @@ def test_account_init(mock_deploy):
     mock_deploy.assert_called_once()
 
 
-def test_account_init_account_exists():
+def test_account_multiple_inits_with_same_key():
     account = Account(KEY, NETWORK)
     account.deploy()
     account2 = Account(KEY, NETWORK)
@@ -85,6 +85,8 @@ def test_send_nonce_call(mock_call):
 
 @pytest.mark.parametrize(
     "callarray, calldata",
+    # The following callarray and calldata args tests the Account's list comprehensions
+    # ensuring they're set to strings and passed correctly
     [([[111]], []), ([[111, 222]], [333, 444, 555])],
 )
 def test_send_sign_transaction_and_execute(callarray, calldata):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ isolated_build = True
 description = Invoke pytest to run automated tests
 setenv =
     TOXINIDIR = {toxinidir}
+    TEST_KEY = 1234
 passenv =
     HOME
 extras =


### PR DESCRIPTION
This PR proposes to add tests for the Account class and the methods therein. This PR adds `TEST_KEY` to the `setenv` in tox which allows for Account instances to be set with the test private key. Further, this proposed PR brings pytest coverage of the account.py module to 95% (the other 5% consists of the try/except import from #85). This resolves #71 (in conjunction with #94).