### PR TITLE
Add `max_fee` to `call` and `invoke` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,12 @@ A few things to notice here:
 Execute a transaction through the `Account` associated with the private key provided. The syntax is:
 
 ```sh
-nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...]
+nile send <private_key_alias> <contract_identifier> <method> [OPTIONS] [PARAM_1, PARAM2...]
+
+OPTIONS:
+  --network TEXT     Select network, one of ('localhost', 'goerli', 'mainnet')
+  --max_fee INTEGER  The maximal fee to be paid for the function invocation.
+  --help             Show this message and exit.
 ```
 
 For example:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,12 @@ Transaction hash: 0x1c
 Using `call` and `invoke`, we can perform read and write operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
 
 ```
-nile <command> <contract_identifier> <method> [PARAM_1, PARAM2...]
+nile <command> <contract_identifier> <method> [OPTIONS] [PARAM_1, PARAM2...]
+
+OPTIONS:
+  --network TEXT     Select network, one of ('localhost', 'goerli', 'mainnet')
+  --max_fee INTEGER  The maximal fee to be paid for the function invocation.
+  --help             Show this message and exit.
 ```
 
 Where `<command>` is either `call` or `invoke` and `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -39,7 +39,7 @@ def max_fee_option(f):
     return click.option(
         "--max_fee",
         nargs=1,
-        help=f"The maximal fee to be paid for the function invocation.",
+        help="The maximal fee to be paid for the function invocation.",
         type=int,
     )(f)
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -12,9 +12,9 @@ from nile.core.deploy import deploy as deploy_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command
+from nile.core.plugins import load_plugins
 from nile.core.run import run as run_command
 from nile.core.test import test as test_command
-from nile.core.plugins import load_plugins
 from nile.core.version import version as version_command
 from nile.utils.debug import debug as debug_command
 
@@ -31,6 +31,16 @@ def network_option(f):
         default="127.0.0.1",
         help=f"Select network, one of {NETWORKS}",
         callback=_validate_network,
+    )(f)
+
+
+def max_fee_option(f):
+    """Configure MAX_FEE for the function invocation."""
+    return click.option(
+        "--max_fee",
+        nargs=1,
+        help=f"The maximal fee to be paid for the function invocation.",
+        type=int,
     )(f)
 
 
@@ -97,9 +107,10 @@ def setup(signer, network):
 @click.argument("signer", nargs=1)
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
+@max_fee_option
 @click.argument("params", nargs=-1)
 @network_option
-def send(signer, contract_name, method, params, network):
+def send(signer, contract_name, method, max_fee, params, network):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
     account = Account(signer, network)
     print(
@@ -107,29 +118,35 @@ def send(signer, contract_name, method, params, network):
             method, contract_name, [x for x in params]
         )
     )
-    out = account.send(contract_name, method, params)
+    out = account.send(contract_name, method, params, max_fee)
     print(out)
 
 
 @cli.command()
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
+@max_fee_option
 @click.argument("params", nargs=-1)
 @network_option
-def invoke(contract_name, method, params, network):
+def invoke(contract_name, method, max_fee, params, network):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "invoke", method, params, network)
+    out = call_or_invoke_command(
+        contract_name, "invoke", method, params, network, max_fee
+    )
     print(out)
 
 
 @cli.command()
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
+@max_fee_option
 @click.argument("params", nargs=-1)
 @network_option
-def call(contract_name, method, params, network):
+def call(contract_name, method, max_fee, params, network):
     """Call functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "call", method, params, network)
+    out = call_or_invoke_command(
+        contract_name, "call", method, params, network, max_fee
+    )
     print(out)
 
 

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -50,7 +50,7 @@ class Account:
 
         return address, index
 
-    def send(self, to, method, calldata, nonce=None):
+    def send(self, to, method, calldata, max_fee=None, nonce=None):
         """Execute a tx going through an Account contract."""
         target_address, _ = next(deployments.load(to, self.network)) or to
         calldata = [int(x) for x in calldata]
@@ -77,5 +77,6 @@ class Account:
             method="__execute__",
             params=params,
             network=self.network,
+            max_fee=max_fee,
             signature=[str(sig_r), str(sig_s)],
         )

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -6,7 +6,9 @@ from nile import deployments
 from nile.common import GATEWAYS
 
 
-def call_or_invoke(contract, type, method, params, network, signature=None):
+def call_or_invoke(
+    contract, type, method, params, network, max_fee=None, signature=None
+):
     """Call or invoke functions of StarkNet smart contracts."""
     address, abi = next(deployments.load(contract, network))
 
@@ -32,6 +34,10 @@ def call_or_invoke(contract, type, method, params, network, signature=None):
     if len(params) > 0:
         command.append("--inputs")
         command.extend(params)
+
+    if max_fee is not None:
+        command.append("--max_fee")
+        command.extend(str(max_fee))
 
     if signature is not None:
         command.append("--signature")

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -26,17 +26,17 @@ class NileRuntimeEnvironment:
             arguments = []
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
-    def call(self, contract, method, params=None):
+    def call(self, contract, method, params=None, max_fee=None):
         """Call a view function in a smart contract."""
         if params is None:
             params = []
-        return call_or_invoke(contract, "call", method, params, self.network)
+        return call_or_invoke(contract, "call", method, params, self.network, max_fee)
 
-    def invoke(self, contract, method, params=None):
+    def invoke(self, contract, method, params=None, max_fee=None):
         """Invoke a mutable function in a smart contract."""
         if params is None:
             params = []
-        return call_or_invoke(contract, "invoke", method, params, self.network)
+        return call_or_invoke(contract, "invoke", method, params, self.network, max_fee)
 
     def get_deployment(self, contract):
         """Get a deployment by its identifier (address or alias)."""


### PR DESCRIPTION
## Description

Fixes #96 (at least aims to).

I couldn't replicate the issue but I didn't know exactly how although I tried to send many invocations in different networks, but I can confirm it's working after the change and is backwards compatible since the `max_fee` param is not necessary.

btw, I didn't understand why the guy in the original issue is saying we're setting `max_fee` to `0.00003` ETH, there's nothing in OZ code, and Starket's code [sets to 0 by default](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/cli/starknet_cli.py#L503)

Also, I didn't find any relevant tests to update.

### Let me know:

1. How can I improve this PR? (I want to learn 😄 )
2. What else can I try to replicate the issue
3. If there's any test requirement to be met