### PR TITLE
Remove Python3.10 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add py3.10-dev once cairo-lang resolves frozendict issue
+        # Add '3.10-dev' once frozendict issue is resolved
         python_version: [ '3.7', '3.8', '3.9' ]
         os: [ubuntu-latest]
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [ '3.7', '3.8', '3.9', '3.10-dev' ]
+        # Add py3.10-dev once cairo-lang resolves frozendict issue
+        python_version: [ '3.7', '3.8', '3.9' ]
         os: [ubuntu-latest]
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Add '3.10-dev' once frozendict issue is resolved
+        # See https://github.com/starkware-libs/cairo-lang/issues/38
         python_version: [ '3.7', '3.8', '3.9' ]
         os: [ubuntu-latest]
     name: ${{ matrix.os }} - Python ${{ matrix.python_version }}


### PR DESCRIPTION
This PR proposes to remove Python3.10-dev from CI. A few points:
- Python3.10 requires > `greenlet v1.1`, but cairo-lang installs 0.4.17
    - this is easy enough to fix in tox, but the [pinned `frozendict` issue](https://github.com/starkware-libs/cairo-lang/issues/27) resurfaces
- there's a PR draft in cairo-lang's repo that aims to enable support for Python3.9 and 3.10 [here](https://github.com/starkware-libs/cairo-lang/pull/43), but again, it's a draft
- because Nile already announced the release of v0.6.0, we shouldn't wait on an outside fix
- once dependency issues are resolved with Python3.10, reimplementing it in CI is extremely easy