### PR TITLE
Pin marshmallow-dataclass to non-breaking version, gitignore node.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # vscode project settings
 .vscode/
+
+# nile
+*node.json*

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -12,9 +12,9 @@ from nile.core.deploy import deploy as deploy_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command
+from nile.core.plugins import load_plugins
 from nile.core.run import run as run_command
 from nile.core.test import test as test_command
-from nile.core.plugins import load_plugins
 from nile.core.version import version as version_command
 from nile.utils.debug import debug as debug_command
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ extras =
 deps =
     werkzeug==2.0.0
     starknet-devnet
+    # See https://github.com/starkware-libs/cairo-lang/issues/52
+    marshmallow-dataclass==8.5.3
 commands =
     pytest {posargs}
 


### PR DESCRIPTION
This PR proposes to include a pin on `marshmallow-dataclass` to its previous (working) version. It's a dependency of cairo-lang ([issue here](https://github.com/starkware-libs/cairo-lang/issues/52)), and this repo's `Signer` test will fail otherwise. This PR also proposes to globally .gitignore `node.json`.