### PR TITLE
Automate account flag during compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ nile compile contracts/MyContract.cairo # compiles single contract
 nile compile contracts/MyContract.cairo --disable-hint-validation # compiles single contract with unwhitelisted hints
 ```
 
-As of cairo-lang v0.8.0, account contracts (contracts with the `__execute__` method) must be compiled with the `--account_contract` flag.
+As of cairo-lang v0.8.0, account contracts (contracts with the `__execute__` method) must be compiled with the `--account_contract` flag. Nile automatically inserts the flag if the contract's name ends with `Account` i.e. Account.cairo, EthAccount.cairo. Otherwise, the flag must be included by the user.
 
 ```sh
-nile compile contracts/MyAccount.cairo --account_contract # compiles account contract
+nile compile contracts/NewAccountType.cairo --account_contract # compiles account contract
 ```
 
 Example output:

--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -66,7 +66,7 @@ def _compile_contract(
         --abi {ABIS_DIRECTORY}/{filename}.json
     """
 
-    if account_contract:
+    if account_contract or filename.endswith("Account"):
         cmd = cmd + "--account_contract"
 
     if disable_hint_validation:

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -116,6 +116,42 @@ def test__compile_account_contract(mock_subprocess):
     mock_process.communicate.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "contract_name, flag",
+    [
+        ("Account", "--account_contract"),
+        ("mock_Account", "--account_contract"),
+        ("Account_Manager", False),
+    ],
+)
+def test__compile_auto_account_flag(mock_subprocess, contract_name, flag):
+    path = f"path/to/{contract_name}.cairo"
+
+    mock_process = Mock()
+    mock_subprocess.Popen.return_value = mock_process
+
+    _compile_contract(path)
+
+    returned_subprocess = [
+        "starknet-compile",
+        path,
+        f"--cairo_path={CONTRACTS_DIRECTORY}",
+        "--output",
+        f"artifacts/{contract_name}.json",
+        "--abi",
+        f"artifacts/abis/{contract_name}.json",
+    ]
+
+    if flag is not False:
+        returned_subprocess.append(flag)
+
+    mock_subprocess.Popen.assert_called_once_with(
+        returned_subprocess,
+        stdout=mock_subprocess.PIPE,
+    )
+    mock_process.communicate.assert_called_once()
+
+
 def test__compile_contract_without_hint_validation(mock_subprocess):
     contract_name_root = "contract_with_unwhitelisted_hints"
     path = f"path/to/{contract_name_root}.cairo"


### PR DESCRIPTION
This PR proposes to automatically include the `--account_contract` flag during compilation if the contract name ends with `Account`. If this is accepted, it:
- sets a precedent that account contracts should suffix their name with `Account`
  - includes the common Account.cairo
- solves the issue of compiling entire libraries such as [OpenZeppelin's Contracts for Cairo](https://github.com/OpenZeppelin/cairo-contracts)
- will not trigger for contract names such as AccountManager.cairo
- can still be triggered for uncommon contract names manually
- sets the sole restriction that non-account contracts should not suffix their name with `Account`

This resolves #102.

---

I think it'd be a good idea to add a directive (`%`) for account contracts as mentioned [here](https://github.com/OpenZeppelin/nile/issues/102#issuecomment-1104274490) by @JulissaDantes. This will probably have to be done in the [StarkNet compiler.](https://github.com/starkware-libs/cairo-lang/tree/64a7f6aed9757d3d8d6c28bd972df73272b0cb0a/src/starkware/starknet/compiler)