### PR TITLE
Added standalone_mode injection for command return value.

### DIFF
--- a/src/nile/core/plugins.py
+++ b/src/nile/core/plugins.py
@@ -15,10 +15,14 @@ def skip_click_exit(func):
     """
 
     @functools.wraps(func)
-    # Click commands only manages keyword arguments
     def wrapper(*args, **kwargs):
+        # add standalone_mode=False to command execution
+        # this enables command returns
+        # more info: https://click.palletsprojects.com/en/5.x/commands/?highlight=standalone_mode#command-return-values # noqa: E501
         try:
-            return func(*args, **kwargs)
+            return func(*args, standalone_mode=False, **kwargs)
+        # click commands always raise a SystemExit
+        # this avoid exiting the command execution in NRE
         except SystemExit:
             pass
 

--- a/tests/core/test_plugins.py
+++ b/tests/core/test_plugins.py
@@ -12,15 +12,17 @@ from nile.core.plugins import get_installed_plugins, load_plugins, skip_click_ex
 
 
 def test_skip_click_exit():
+    @click.command()
+    @click.argument('a', type=int)
+    @click.argument('b', type=int)
     def dummy_method(a, b):
         return a + b
 
-    dummy_result = dummy_method(1, 2)
     decorated = skip_click_exit(dummy_method)
-    decorated_result = decorated(1, 2)
+    decorated_result = decorated(["1", "2"])
 
     assert callable(decorated)
-    assert dummy_result == decorated_result
+    assert decorated_result == 3
 
 
 def testget_installed_plugins():
@@ -39,6 +41,7 @@ def test_load_plugins():
         """Nile CLI group."""
         pass
 
+    @click.command()
     def dummy():
         print("dummy_result")
 

--- a/tests/core/test_plugins.py
+++ b/tests/core/test_plugins.py
@@ -13,8 +13,8 @@ from nile.core.plugins import get_installed_plugins, load_plugins, skip_click_ex
 
 def test_skip_click_exit():
     @click.command()
-    @click.argument('a', type=int)
-    @click.argument('b', type=int)
+    @click.argument("a", type=int)
+    @click.argument("b", type=int)
     def dummy_method(a, b):
         return a + b
 

--- a/tests/test_nre.py
+++ b/tests/test_nre.py
@@ -6,13 +6,19 @@ Only unit tests for now.
 
 from unittest.mock import patch
 
+import click
+
 from nile.nre import NileRuntimeEnvironment
 
 
 def test_nre_loaded_plugins():
+    @click.command()
     def dummy():
         print("dummy_result")
 
+    @click.command()
+    @click.argument('a', type=int)
+    @click.argument('b', type=int)
     def dummy_params(a, b):
         return a + b
 
@@ -22,6 +28,6 @@ def test_nre_loaded_plugins():
     ):
         nre = NileRuntimeEnvironment()
         assert callable(nre.dummy)
-        dummy_result = dummy_params(1, 2)
-        nre_result = nre.dummy_params(1, 2)
-        assert dummy_result == nre_result
+        
+        nre_result = nre.dummy_params(["1", "2"])
+        assert 3 == nre_result

--- a/tests/test_nre.py
+++ b/tests/test_nre.py
@@ -17,8 +17,8 @@ def test_nre_loaded_plugins():
         print("dummy_result")
 
     @click.command()
-    @click.argument('a', type=int)
-    @click.argument('b', type=int)
+    @click.argument("a", type=int)
+    @click.argument("b", type=int)
     def dummy_params(a, b):
         return a + b
 
@@ -28,6 +28,6 @@ def test_nre_loaded_plugins():
     ):
         nre = NileRuntimeEnvironment()
         assert callable(nre.dummy)
-        
+
         nre_result = nre.dummy_params(["1", "2"])
         assert 3 == nre_result


### PR DESCRIPTION
Resolves #107. This solution injects the argument `standalone_mode=False` to click's command execution to enable return values in commands.

Also, I identified an issue while using arguments and options in commands through the NRE. To pass arguments and options from a command, it is needed to follow click guidelines. These guidelines specify that should be passed as a list of items in string format:

```python
# Decorate the method that will be the command name with `click.command`
@click.command()
@click.argument("a", type=int)
@click.argument("b", type=int)
# You can define custom parameters as defined in `click`: https://click.palletsprojects.com/en/7.x/options/
def greet(a, b):
    # Help message to show with the command
    """
    Subcommand plugin that does something.
    """
    # Done! Now implement your custom functionality in the command
    click.echo("Hello! I'm a Nile plugin")
    return a + b
```

For example, to use it with the NRE:

```python
from nile.nre import NileRuntimeEnvironment

nre = NileRuntimeEnvironment()
ret = nre.greet(["1", "2"])
# ret is equal to 3
```