### PR TITLE
Reduce `subprocess` verbosity on call, or involke, error

### DIFF
--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -1,4 +1,5 @@
 """Command to call or invoke StarkNet smart contracts."""
+import contextlib
 import os
 import subprocess
 
@@ -37,4 +38,6 @@ def call_or_invoke(contract, type, method, params, network, signature=None):
         command.append("--signature")
         command.extend(signature)
 
-    return subprocess.check_output(command).strip().decode("utf-8")
+    with contextlib.suppress(subprocess.CalledProcessError):
+        return subprocess.check_output(command).strip().decode("utf-8")
+    return ""


### PR DESCRIPTION
Maybe reducing `subprocess` exception could be a first step until a better error reporting?

May close #117.

Before the patch:

```python
Got BadRequest while trying to access https://alpha4.starknet.io/feeder_gateway/call_contract?blockNumber=null. Status code: 500; text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}.
Traceback (most recent call last):
  File "./venv/lib/python3.9/site-packages/services/external_api/base_client.py", line 120, in _send_request
    raise BadRequest(status_code=response.status, text=text)
services.external_api.base_client.BadRequest: HTTP error ocurred. Status: 500. Text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}
Error: BadRequest: HTTP error ocurred. Status: 500. Text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}
Traceback (most recent call last):
  File "./venv/bin/nile", line 8, in <module>
    sys.exit(cli())
  File "./venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "./venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "./venv/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "./venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "./venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "./venv/lib/python3.9/site-packages/nile/cli.py", line 132, in call
    out = call_or_invoke_command(contract_name, "call", method, params, network)
  File "./venv/lib/python3.9/site-packages/nile/core/call_or_invoke.py", line 40, in call_or_invoke
    return subprocess.check_output(command).strip().decode("utf-8")
  File "/usr/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['starknet', 'call', '--address', '0x123', '--abi', 'artifacts/abis/ERC721.json', '--function', 'get_animal_characteristics', '--inputs', '42', '0']' returned non-zero exit status 1.
```

With the patch:

```python
Got BadRequest while trying to access https://alpha4.starknet.io/feeder_gateway/call_contract?blockNumber=null. Status code: 500; text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}.
Traceback (most recent call last):
  File "./venv/lib/python3.9/site-packages/services/external_api/base_client.py", line 120, in _send_request
    raise BadRequest(status_code=response.status, text=text)
services.external_api.base_client.BadRequest: HTTP error ocurred. Status: 500. Text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}
Error: BadRequest: HTTP error ocurred. Status: 500. Text: {"code": "StarknetErrorCode.UNINITIALIZED_CONTRACT", "message": "Contract with address 0x123 is not deployed."}

```