### PR TITLE
Update to cairo-lang v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ Please note:
 
 - `localhost` is the default network. Add `--network <network>` to change the network for the script
 
+### `get_declaration` (NRE only)
+
+Return the hash of a declared class. This can be useful in scenarios where a contract class is already declared with an alias prior to running a script.
+
+```python
+def run(nre):
+    predeclared_class = nre.get_declaration("alias")
+```
+
+> Note that this command is only available in the context of scripting in the Nile Runtime Environment.
+
 ### `clean`
 
 Deletes the `artifacts/` directory for a fresh start ❄️

--- a/README.md
+++ b/README.md
@@ -146,31 +146,44 @@ A few things to notice here:
 
 ### `send`
 
-Execute a transaction through the `Account` associated with the private key provided. The syntax is:
+Execute a transaction through the `Account` associated with the private key provided.  The syntax is:
 
 ```sh
-nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...] <max_fee>
+nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...]
 ```
 
 For example:
 
 ```sh
-nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794 600000000000000 
+nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794
 
 Invoke transaction was sent.
 Contract address: 0x07db6b52c8ab888183277bc6411c400136fe566c0eebfb96fffa559b2e60e794
 Transaction hash: 0x1c
 ```
 
+Some things to note:
+
+- `max_fee` defaults to `0`. Add `--max_fee <max_fee>` to set the maximum fee for the transaction
+- `network` defaults to the `localhost`. Add `--network <network>` to change the network for the transaction
+
 ### `call` and `invoke`
 
-Using `call`, we can perform read operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
+Using `call` and `invoke`, we can perform read and write operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
 
 ```sh
-nile `call` <contract_identifier> <method> [PARAM_1, PARAM2...]
+nile <command> <contract_identifier> <method> [PARAM_1, PARAM2...]
 ```
 
-Where `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.
+Where `<command>` is either `call` or `invoke` and `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.
+
+```sh
+nile invoke my_contract increase_balance 1
+
+Invoke transaction was sent.
+Contract address: 0x07ec10eb0758f7b1bc5aed0d5b4d30db0ab3c087eba85d60858be46c1a5e4680
+Transaction hash: 0x1
+```
 
 ```sh
 nile call my_contract get_balance
@@ -178,9 +191,9 @@ nile call my_contract get_balance
 1
 ```
 
-`invoke` is now deprecated. StarkNet enforces fees; thus, users must use an account to execute write transactions (and pay for fees). See [nile send](#send).
+Please note:
 
-> Note that the local node still supports `nile invoke` for the time being.
+- `network` defaults to the `localhost`. Add `--network <network>` to change the network for the transaction
 
 ### `run`
 
@@ -199,6 +212,10 @@ Then run the script:
 ```sh
 nile run path/to/script.py
 ```
+
+Please note:
+
+- `localhost` is the default network. Add `--network <network>` to change the network for the script
 
 ### `clean`
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ nile node
    WARNING: This is a development server. Do not use it in a production deployment.
    Use a production WSGI server instead.
  * Debug mode: off
- * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+ * Running on http://127.0.0.1:5050/ (Press CTRL+C to quit)
 ```
 
 ### `compile`

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ A few things to notice here:
 
 ### `send`
 
-Execute a transaction through the `Account` associated with the private key provided.  The syntax is:
+Execute a transaction through the `Account` associated with the private key provided. The syntax is:
 
 ```sh
 nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...]

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ A few things to notice here:
 Execute a transaction through the `Account` associated with the private key provided. The syntax is:
 
 ```sh
-nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...]
+nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...] --max_fee <MAX_FEE>
 ```
 
 For example:
 
 ```sh
-nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794
+nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794 --max_fee 600000000000000 
 
 Invoke transaction was sent.
 Contract address: 0x07db6b52c8ab888183277bc6411c400136fe566c0eebfb96fffa559b2e60e794
@@ -164,27 +164,23 @@ Transaction hash: 0x1c
 
 ### `call` and `invoke`
 
-Using `call` and `invoke`, we can perform read and write operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
+Using `call`, we can perform read operations against our local node (or public one using the `--network mainnet` parameter). The syntax is:
 
 ```sh
-nile <command> <contract_identifier> <method> [PARAM_1, PARAM2...]
+nile `call` <contract_identifier> <method> [PARAM_1, PARAM2...]
 ```
 
-Where `<command>` is either `call` or `invoke` and `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.
-
-```sh
-nile invoke my_contract increase_balance 1
-
-Invoke transaction was sent.
-Contract address: 0x07ec10eb0758f7b1bc5aed0d5b4d30db0ab3c087eba85d60858be46c1a5e4680
-Transaction hash: 0x1
-```
+Where `<contract_identifier>` is either our contract address or alias, as defined on `deploy`.
 
 ```sh
 nile call my_contract get_balance
 
 1
 ```
+
+`invoke` is now deprecated. StarkNet enforces fees; thus, users must use an account to execute write transactions (and pay for fees). See [nile send](#send).
+
+> Note that the local node still supports `nile invoke` for the time being.
 
 ### `run`
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ A few things to notice here:
 3. The `--alias` parameter lets me create an unique identifier for future interactions, if no alias is set then the contract's address can be used as identifier
 4. By default Nile works on local, but you can use the `--network` parameter to interact with `mainnet`, `goerli`, and the default `localhost`.
 
+### `declare`
+
+```sh
+nile declare contract --alias my_contract
+
+🚀 Declaring contract
+⏳ Declaration of contract successfully sent at 0x07ec10eb0758f7b1bc5aed0d5b4d30db0ab3c087eba85d60858be46c1a5e4680
+📦 Registering declaration as my_contract in localhost.declarations.txt
+```
+
+A few things to notice here:
+
+1. `nile declare <contract_name>` looks for an artifact with the same name
+2. This created a `localhost.declarations.txt` file storing all data related to my declarations
+3. The `--alias` parameter lets me create an unique identifier for future interactions, if no alias is set then the contract's address can be used as identifier
+4. By default Nile works on local, but you can use the `--network` parameter to interact with `mainnet`, `goerli`, and the default `localhost`.
+
 ### `setup`
 
 Deploy an Account associated with a given private key.
@@ -217,7 +234,7 @@ nile version
 
 ### `debug`
 
-Use locally available contracts to make error messages from rejected transactions more explicit.  
+Use locally available contracts to make error messages from rejected transactions more explicit.
 
 ```sh
 nile debug <transaction_hash> [CONTRACTS_FILE, NETWORK]
@@ -298,30 +315,30 @@ In order for this implementation to be functional, it is needed by the plugin de
 
 1. Define a Python module that implement a click command or group:
 
-    ```python
-    # First, import click dependency
-    import click
+   ```python
+   # First, import click dependency
+   import click
 
-    # Decorate the method that will be the command name with `click.command` 
-    @click.command()
-    # You can define custom parameters as defined in `click`: https://click.palletsprojects.com/en/7.x/options/
-    def my_command():
-        # Help message to show with the command
-        """
-        Subcommand plugin that does something.
-        """
-        # Done! Now implement your custom functionality in the command
-        click.echo("I'm a plugin overiding a command!")
-    ```
+   # Decorate the method that will be the command name with `click.command`
+   @click.command()
+   # You can define custom parameters as defined in `click`: https://click.palletsprojects.com/en/7.x/options/
+   def my_command():
+       # Help message to show with the command
+       """
+       Subcommand plugin that does something.
+       """
+       # Done! Now implement your custom functionality in the command
+       click.echo("I'm a plugin overiding a command!")
+   ```
 
 2. Define the plugin entrypoint. In this case using Poetry features in the pyproject.toml file:
 
-    ```sh
-    # We need to specify that click commands are Poetry entrypoints of type `nile_plugins`. Do not modify this
-    [tool.poetry.plugins."nile_plugins"]
-    # Here you specify you command name and location <command_name> = <package_method_location>
-    "greet" = "nile_greet.main.greet"
-    ```
+   ```sh
+   # We need to specify that click commands are Poetry entrypoints of type `nile_plugins`. Do not modify this
+   [tool.poetry.plugins."nile_plugins"]
+   # Here you specify you command name and location <command_name> = <package_method_location>
+   "greet" = "nile_greet.main.greet"
+   ```
 
 3. Done!
 
@@ -334,20 +351,20 @@ Finally, after the desired plugin is installed, it will also be automatically av
 Nile uses tox to manage development tasks, you can get a list of
 available task with `tox -av`.
 
-* Install a development version of the package with `python -m pip install .`
-* Build the package with `tox -e build`
-* Format all files with `tox -e format`
-* Check files formatting with `tox -e lint`
+- Install a development version of the package with `python -m pip install .`
+- Build the package with `tox -e build`
+- Format all files with `tox -e format`
+- Check files formatting with `tox -e lint`
 
 ### Testing
 
 To run tests:
 
-* Install testing dependencies with `python -m pip install .[testing]`
-* Run all tests with `tox`
-* Run unit tests only with `tox -e unit`
-* To run a specific set of tests, point to a module and/or function, e.g. `toxtests/test_module.py::test_function`
-* Other `pytest` flags must be preceded by `--`, e.g. `tox -- --pdb` to runtests in debug mode
+- Install testing dependencies with `python -m pip install .[testing]`
+- Run all tests with `tox`
+- Run unit tests only with `tox -e unit`
+- To run a specific set of tests, point to a module and/or function, e.g. `toxtests/test_module.py::test_function`
+- Other `pytest` flags must be preceded by `--`, e.g. `tox -- --pdb` to runtests in debug mode
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -149,13 +149,13 @@ A few things to notice here:
 Execute a transaction through the `Account` associated with the private key provided. The syntax is:
 
 ```sh
-nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...] --max_fee <MAX_FEE>
+nile send <private_key_alias> <contract_identifier> <method> [PARAM_1, PARAM2...] <max_fee>
 ```
 
 For example:
 
 ```sh
-nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794 --max_fee 600000000000000 
+nile send <private_key_alias> ownable0 transfer_ownership 0x07db6...60e794 600000000000000 
 
 Invoke transaction was sent.
 Contract address: 0x07db6b52c8ab888183277bc6411c400136fe566c0eebfb96fffa559b2e60e794

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -191,16 +191,17 @@ def clean():
 @cli.command()
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=5000)
-def node(host, port):
+@click.option("--accounts", default=2)
+def node(host, port, accounts):
     """Start StarkNet local network.
 
     $ nile node
-      Start StarkNet local network at port 5000
+      Start StarkNet local network at port 5000 with 2 accounts
 
-    $ nile node --host HOST --port 5001
-      Start StarkNet network on address HOST listening at port 5001
+    $ nile node --host HOST --port 5001 --accounts 3
+      Start StarkNet network on address HOST listening at port 5001 with 3 accounts
     """
-    node_command(host, port)
+    node_command(host, port, accounts)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -108,10 +108,10 @@ def setup(signer, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.option("--max_fee", nargs=1)
+@click.argument("max_fee", nargs=1)
 @network_option
 def send(signer, contract_name, method, params, max_fee, network):
-    """Invoke a contract's method through an Account."""
+    """Invoke a contract's method through an Account. Same usage as nile invoke."""
     account = Account(signer, network)
     print(
         "Calling {} on {} with params: {}".format(

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -130,7 +130,9 @@ def send(signer, contract_name, method, params, network, max_fee=None):
 @network_option
 def invoke(contract_name, method, params, network, max_fee=None):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "invoke", method, params, network, max_fee=max_fee)
+    out = call_or_invoke_command(
+        contract_name, "invoke", method, params, network, max_fee=max_fee
+    )
     print(out)
 
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -88,10 +88,9 @@ def deploy(artifact, arguments, network, alias):
 
 @cli.command()
 @click.argument("artifact", nargs=1)
-@click.argument("arguments", nargs=-1)
 @network_option
 @click.option("--alias")
-def declare(artifact, arguments, network, alias):
+def declare(artifact, network, alias):
     """Declare StarkNet smart contract."""
     declare_command(artifact, network, alias)
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -199,10 +199,10 @@ def node(host, port):
     """Start StarkNet local network.
 
     $ nile node
-      Start StarkNet local network at port 5050 with 2 accounts
+      Start StarkNet local network at port 5050
 
     $ nile node --host HOST --port 5001
-      Start StarkNet network on address HOST listening at port 5001 with 3 accounts
+      Start StarkNet network on address HOST listening at port 5001
     """
     node_command(host, port)
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -9,6 +9,7 @@ from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
 from nile.core.deploy import deploy as deploy_command
+from nile.core.declare import declare as declare_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command
@@ -83,6 +84,16 @@ def run(path, network):
 def deploy(artifact, arguments, network, alias):
     """Deploy StarkNet smart contract."""
     deploy_command(artifact, arguments, network, alias)
+
+
+@cli.command()
+@click.argument("artifact", nargs=1)
+@click.argument("arguments", nargs=-1)
+@network_option
+@click.option("--alias")
+def declare(artifact, arguments, network, alias):
+    """Declare StarkNet smart contract."""
+    declare_command(artifact, network, alias)
 
 
 @cli.command()

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -8,8 +8,8 @@ from nile.core.account import Account
 from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
-from nile.core.deploy import deploy as deploy_command
 from nile.core.declare import declare as declare_command
+from nile.core.deploy import deploy as deploy_command
 from nile.core.init import init as init_command
 from nile.core.install import install as install_command
 from nile.core.node import node as node_command

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -108,10 +108,10 @@ def setup(signer, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.argument("max_fee", nargs=1)
+@click.option("--max_fee", nargs=1)
 @network_option
 def send(signer, contract_name, method, params, max_fee, network):
-    """Invoke a contract's method through an Account. Same usage as nile invoke."""
+    """Invoke a contract's method through an Account."""
     account = Account(signer, network)
     print(
         "Calling {} on {} with params: {}".format(
@@ -126,13 +126,10 @@ def send(signer, contract_name, method, params, max_fee, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.argument("max_fee", nargs=1)
 @network_option
-def invoke(contract_name, method, params, max_fee, network):
+def invoke(contract_name, method, params, network):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(
-        contract_name, "invoke", method, params, network, max_fee=max_fee
-    )
+    out = call_or_invoke_command(contract_name, "invoke", method, params, network)
     print(out)
 
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -130,8 +130,9 @@ def send(signer, contract_name, method, params, max_fee, network):
 @network_option
 def invoke(contract_name, method, params, max_fee, network):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "invoke",
-                                 method, params, network, max_fee=max_fee)
+    out = call_or_invoke_command(
+        contract_name, "invoke", method, params, network, max_fee=max_fee
+    )
     print(out)
 
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -108,9 +108,9 @@ def setup(signer, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
-@click.argument("max_fee", nargs=1)
+@click.option("--max_fee", nargs=1)
 @network_option
-def send(signer, contract_name, method, params, max_fee, network):
+def send(signer, contract_name, method, params, network, max_fee=None):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
     account = Account(signer, network)
     print(
@@ -126,10 +126,11 @@ def send(signer, contract_name, method, params, max_fee, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
+@click.option("--max_fee", nargs=1)
 @network_option
-def invoke(contract_name, method, params, network):
+def invoke(contract_name, method, params, network, max_fee=None):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "invoke", method, params, network)
+    out = call_or_invoke_command(contract_name, "invoke", method, params, network, max_fee=max_fee)
     print(out)
 
 

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -29,7 +29,7 @@ def network_option(f):
     return click.option(  # noqa: E731
         "--network",
         envvar="STARKNET_NETWORK",
-        default="127.0.0.1",
+        default="localhost",
         help=f"Select network, one of {NETWORKS}",
         callback=_validate_network,
     )(f)
@@ -42,7 +42,7 @@ def _validate_network(_ctx, _param, value):
         return "goerli"
     # normalize localhost
     if "localhost" in value or "127.0.0.1" in value:
-        return "127.0.0.1"
+        return "localhost"
     # check if value is accepted
     if value in NETWORKS:
         return value

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -108,8 +108,9 @@ def setup(signer, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
+@click.argument("max_fee", nargs=1)
 @network_option
-def send(signer, contract_name, method, params, network):
+def send(signer, contract_name, method, params, max_fee, network):
     """Invoke a contract's method through an Account. Same usage as nile invoke."""
     account = Account(signer, network)
     print(
@@ -117,7 +118,7 @@ def send(signer, contract_name, method, params, network):
             method, contract_name, [x for x in params]
         )
     )
-    out = account.send(contract_name, method, params)
+    out = account.send(contract_name, method, params, max_fee=max_fee)
     print(out)
 
 
@@ -125,10 +126,12 @@ def send(signer, contract_name, method, params, network):
 @click.argument("contract_name", nargs=1)
 @click.argument("method", nargs=1)
 @click.argument("params", nargs=-1)
+@click.argument("max_fee", nargs=1)
 @network_option
-def invoke(contract_name, method, params, network):
+def invoke(contract_name, method, params, max_fee, network):
     """Invoke functions of StarkNet smart contracts."""
-    out = call_or_invoke_command(contract_name, "invoke", method, params, network)
+    out = call_or_invoke_command(contract_name, "invoke",
+                                 method, params, network, max_fee=max_fee)
     print(out)
 
 
@@ -190,18 +193,17 @@ def clean():
 
 @cli.command()
 @click.option("--host", default="127.0.0.1")
-@click.option("--port", default=5000)
-@click.option("--accounts", default=2)
-def node(host, port, accounts):
+@click.option("--port", default=5050)
+def node(host, port):
     """Start StarkNet local network.
 
     $ nile node
-      Start StarkNet local network at port 5000 with 2 accounts
+      Start StarkNet local network at port 5050 with 2 accounts
 
-    $ nile node --host HOST --port 5001 --accounts 3
+    $ nile node --host HOST --port 5001
       Start StarkNet network on address HOST listening at port 5001 with 3 accounts
     """
-    node_command(host, port, accounts)
+    node_command(host, port)
 
 
 @cli.command()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -24,7 +24,7 @@ def _get_gateway():
 
     except FileNotFoundError:
         with open(NODE_FILENAME, "w") as f:
-            f.write('{"localhost": "http://127.0.0.1:5000/"}')
+            f.write('{"localhost": "http://127.0.0.1:5050/"}')
 
 
 GATEWAYS = _get_gateway()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -1,6 +1,7 @@
 """nile common module."""
 import json
 import os
+import re
 import subprocess
 
 CONTRACTS_DIRECTORY = "contracts"

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -54,7 +54,7 @@ def run_command(
         overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
     )
     contract = f"{base_path[0]}/{contract_name}.json"
-    command = ["starknet", "declare", "--contract", contract]
+    command = ["starknet", operation, "--contract", contract]
 
     if arguments:
         command.append("--inputs")

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -7,6 +7,7 @@ BUILD_DIRECTORY = "artifacts"
 TEMP_DIRECTORY = ".temp"
 ABIS_DIRECTORY = f"{BUILD_DIRECTORY}/abis"
 DEPLOYMENTS_FILENAME = "deployments.txt"
+DECLARATIONS_FILENAME = "declarations.txt"
 ACCOUNTS_FILENAME = "accounts.json"
 NODE_FILENAME = "node.json"
 RETRY_AFTER_SECONDS = 30

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -1,6 +1,7 @@
 """nile common module."""
 import json
 import os
+import subprocess
 
 CONTRACTS_DIRECTORY = "contracts"
 BUILD_DIRECTORY = "artifacts"
@@ -42,3 +43,27 @@ def get_all_contracts(ext=None, directory=None):
         ]
 
     return files
+
+
+def run_command(
+    contract_name, network, overriding_path=None, operation="deploy", arguments=None
+):
+    """Execute CLI command with given parameters."""
+    base_path = (
+        overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
+    )
+    contract = f"{base_path[0]}/{contract_name}.json"
+    command = ["starknet", "declare", "--contract", contract]
+
+    if arguments:
+        command.append("--inputs")
+        command.extend([argument for argument in arguments])
+
+    if network == "mainnet":
+        os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
+    elif network == "goerli":
+        os.environ["STARKNET_NETWORK"] = "alpha-goerli"
+    else:
+        command.append(f"--gateway_url={GATEWAYS.get(network)}")
+
+    return subprocess.check_output(command)

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -67,3 +67,10 @@ def run_command(
         command.append(f"--gateway_url={GATEWAYS.get(network)}")
 
     return subprocess.check_output(command)
+
+
+def parse_information(x):
+    """Extract information from deploy/declare command."""
+    # address is 64, tx_hash is 64 chars long
+    address, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
+    return address, tx_hash

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -61,7 +61,7 @@ class Account:
             )
 
         (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(
-            sender=self.address, calls=[[target_address, method, calldata]], nonce=nonce
+            sender=self.address, calls=[[target_address, method, calldata]], nonce=nonce, max_fee=max_fee
         )
 
         params = []

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -20,7 +20,7 @@ class Account:
 
     def __init__(self, signer, network):
         """Get or deploy an Account contract for the given private key."""
-        self.signer = Signer(int(os.environ[signer]))
+        self.signer = Signer(int(os.environ[signer], 16))
         self.network = network
 
         if accounts.exists(str(self.signer.public_key), network):

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -60,6 +60,9 @@ class Account:
                 call_or_invoke(self.address, "call", "get_nonce", [], self.network)
             )
 
+        if max_fee is None:
+            max_fee = 0
+
         (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(
             sender=self.address,
             calls=[[target_address, method, calldata]],

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -50,7 +50,7 @@ class Account:
 
         return address, index
 
-    def send(self, to, method, calldata, nonce=None):
+    def send(self, to, method, calldata, nonce=None, max_fee=None):
         """Execute a tx going through an Account contract."""
         target_address, _ = next(deployments.load(to, self.network)) or to
         calldata = [int(x) for x in calldata]
@@ -78,4 +78,5 @@ class Account:
             params=params,
             network=self.network,
             signature=[str(sig_r), str(sig_s)],
+            max_fee=max_fee
         )

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -20,7 +20,7 @@ class Account:
 
     def __init__(self, signer, network):
         """Get or deploy an Account contract for the given private key."""
-        self.signer = Signer(int(os.environ[signer], 16))
+        self.signer = Signer(int(os.environ[signer]))
         self.network = network
 
         if accounts.exists(str(self.signer.public_key), network):

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -50,7 +50,7 @@ class Account:
 
         return address, index
 
-    def send(self, to, method, calldata, nonce=None, max_fee=None):
+    def send(self, to, method, calldata, max_fee, nonce=None):
         """Execute a tx going through an Account contract."""
         target_address, _ = next(deployments.load(to, self.network)) or to
         calldata = [int(x) for x in calldata]
@@ -59,9 +59,6 @@ class Account:
             nonce = int(
                 call_or_invoke(self.address, "call", "get_nonce", [], self.network)
             )
-
-        if max_fee is None:
-            max_fee = "0"
 
         (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(
             sender=self.address,
@@ -84,5 +81,5 @@ class Account:
             params=params,
             network=self.network,
             signature=[str(sig_r), str(sig_s)],
-            max_fee=max_fee,
+            max_fee=str(max_fee),
         )

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -61,7 +61,10 @@ class Account:
             )
 
         (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(
-            sender=self.address, calls=[[target_address, method, calldata]], nonce=nonce, max_fee=max_fee
+            sender=self.address,
+            calls=[[target_address, method, calldata]],
+            nonce=nonce,
+            max_fee=max_fee,
         )
 
         params = []
@@ -78,5 +81,5 @@ class Account:
             params=params,
             network=self.network,
             signature=[str(sig_r), str(sig_s)],
-            max_fee=max_fee
+            max_fee=max_fee,
         )

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -61,7 +61,7 @@ class Account:
             )
 
         if max_fee is None:
-            max_fee = 0
+            max_fee = "0"
 
         (call_array, calldata, sig_r, sig_s) = self.signer.sign_transaction(
             sender=self.address,

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -2,8 +2,6 @@
 import os
 import subprocess
 
-from starkware.starkware_utils.error_handling import StarkException
-
 from nile import deployments
 from nile.common import GATEWAYS
 
@@ -41,14 +39,9 @@ def call_or_invoke(
         command.append("--signature")
         command.extend(signature)
 
-    command.append("--max_fee")
-    command.append(max_fee)
+    if max_fee is not None:
+        command.append("--max_fee")
+        command.append(max_fee)
 
-    try:
-        output = subprocess.check_output(command).strip().decode("utf-8")
-        return output
-    except StarkException:
-        print("")
-        print("😰 Whooops, looks like max fee is missing. Try with:\n")
-        print("             --max_fee=`MAX_FEE`")
-        print("")
+    output = subprocess.check_output(command).strip().decode("utf-8")
+    return output

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -6,7 +6,9 @@ from nile import deployments
 from nile.common import GATEWAYS
 
 
-def call_or_invoke(contract, type, method, params, network, signature=None, max_fee=None):
+def call_or_invoke(
+    contract, type, method, params, network, signature=None, max_fee=None
+):
     """Call or invoke functions of StarkNet smart contracts."""
     address, abi = next(deployments.load(contract, network))
 

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -39,8 +39,14 @@ def call_or_invoke(
         command.append("--signature")
         command.extend(signature)
 
-    if max_fee is not None:
-        command.append("--max_fee")
-        command.append(str(max_fee))
+    command.append("--max_fee")
+    command.append(str(max_fee))
 
-    return subprocess.check_output(command).strip().decode("utf-8")
+    try:
+        output = subprocess.check_output(command).strip().decode("utf-8")
+        return output
+    except StarkException as e:
+        print("")
+        print("😰 Whooops, looks like max fee is missing. Try with:\n")
+        print("             --max_fee=`MAX_FEE`")
+        print("")

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -2,6 +2,8 @@
 import os
 import subprocess
 
+from starkware.starkware_utils.error_handling import StarkException
+
 from nile import deployments
 from nile.common import GATEWAYS
 
@@ -45,7 +47,7 @@ def call_or_invoke(
     try:
         output = subprocess.check_output(command).strip().decode("utf-8")
         return output
-    except StarkException as e:
+    except StarkException:
         print("")
         print("😰 Whooops, looks like max fee is missing. Try with:\n")
         print("             --max_fee=`MAX_FEE`")

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -1,4 +1,5 @@
 """Command to call or invoke StarkNet smart contracts."""
+import logging
 import os
 import subprocess
 
@@ -43,5 +44,20 @@ def call_or_invoke(
         command.append("--max_fee")
         command.append(max_fee)
 
-    output = subprocess.check_output(command).strip().decode("utf-8")
-    return output
+    try:
+        output = subprocess.check_output(command).strip().decode("utf-8")
+        return output
+
+    except subprocess.CalledProcessError:
+        p = subprocess.Popen(command, stderr=subprocess.PIPE)
+        _, error = p.communicate()
+
+        if "max_fee must be bigger than 0" in error.decode():
+            logging.error(
+                """
+                \n😰 Whoops, looks like max fee is missing. Try with:\n
+                --max_fee=`MAX_FEE`
+                """
+            )
+        else:
+            raise

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -42,7 +42,7 @@ def call_or_invoke(
         command.extend(signature)
 
     command.append("--max_fee")
-    command.append(str(max_fee))
+    command.append(max_fee)
 
     try:
         output = subprocess.check_output(command).strip().decode("utf-8")

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -6,7 +6,7 @@ from nile import deployments
 from nile.common import GATEWAYS
 
 
-def call_or_invoke(contract, type, method, params, network, signature=None):
+def call_or_invoke(contract, type, method, params, network, signature=None, max_fee=None):
     """Call or invoke functions of StarkNet smart contracts."""
     address, abi = next(deployments.load(contract, network))
 
@@ -36,5 +36,9 @@ def call_or_invoke(contract, type, method, params, network, signature=None):
     if signature is not None:
         command.append("--signature")
         command.extend(signature)
+
+    if max_fee is not None:
+        command.append("--max_fee")
+        command.append(str(max_fee))
 
     return subprocess.check_output(command).strip().decode("utf-8")

--- a/src/nile/core/clean.py
+++ b/src/nile/core/clean.py
@@ -3,23 +3,30 @@ import logging
 import os
 import shutil
 
-from nile.common import ACCOUNTS_FILENAME, BUILD_DIRECTORY, DEPLOYMENTS_FILENAME
+from nile.common import (
+    ACCOUNTS_FILENAME,
+    BUILD_DIRECTORY,
+    DECLARATIONS_FILENAME,
+    DEPLOYMENTS_FILENAME,
+)
 
 
 def clean():
     """Remove artifacts from workspace."""
-    local_deployments_filename = f"localhost.{DEPLOYMENTS_FILENAME}"
-    local_accounts_filename = f"localhost.{ACCOUNTS_FILENAME}"
+    local_files = [
+        f"127.0.0.1.{DEPLOYMENTS_FILENAME}",
+        f"127.0.0.1.{DECLARATIONS_FILENAME}",
+        f"127.0.0.1.{ACCOUNTS_FILENAME}",
+        BUILD_DIRECTORY,
+    ]
 
-    if os.path.exists(local_deployments_filename):
-        logging.info(f"🚮 Deleting {local_deployments_filename}")
-        os.remove(local_deployments_filename)
+    for file in local_files:
+        if os.path.exists(file):
+            logging.info(f"🚮 Deleting {file}")
 
-    if os.path.exists(local_accounts_filename):
-        logging.info(f"🚮 Deleting {local_accounts_filename}")
-        os.remove(local_accounts_filename)
+            if file is BUILD_DIRECTORY:
+                shutil.rmtree(BUILD_DIRECTORY)
+            else:
+                os.remove(file)
 
-    if os.path.exists(BUILD_DIRECTORY):
-        logging.info(f"🚮 Deleting {BUILD_DIRECTORY} directory")
-        shutil.rmtree(BUILD_DIRECTORY)
     logging.info("✨ Workspace clean, keep going!")

--- a/src/nile/core/clean.py
+++ b/src/nile/core/clean.py
@@ -14,9 +14,9 @@ from nile.common import (
 def clean():
     """Remove artifacts from workspace."""
     local_files = [
-        f"127.0.0.1.{DEPLOYMENTS_FILENAME}",
-        f"127.0.0.1.{DECLARATIONS_FILENAME}",
-        f"127.0.0.1.{ACCOUNTS_FILENAME}",
+        f"localhost.{DEPLOYMENTS_FILENAME}",
+        f"localhost.{DECLARATIONS_FILENAME}",
+        f"localhost.{ACCOUNTS_FILENAME}",
         BUILD_DIRECTORY,
     ]
 

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -2,12 +2,16 @@
 import logging
 
 from nile import deployments
-from nile.common import parse_information, run_command
+from nile.common import DECLARATIONS_FILENAME, parse_information, run_command
 
 
 def declare(contract_name, network, alias=None, overriding_path=None):
     """Declare StarkNet smart contracts."""
     logging.info(f"🚀 Declaring {contract_name}")
+
+    if alias_exists(alias, network):
+        file = f"{network}.{DECLARATIONS_FILENAME}"
+        raise Exception(f"Alias {alias} already exists in {file}")
 
     output = run_command(contract_name, network, overriding_path, operation="declare")
     class_hash, tx_hash = parse_information(output)
@@ -16,3 +20,9 @@ def declare(contract_name, network, alias=None, overriding_path=None):
 
     deployments.register_class_hash(class_hash, network, alias)
     return class_hash
+
+
+def alias_exists(alias, network):
+    """Return whether an alias exists or not."""
+    existing_alias = next(deployments.load_class(alias, network), None)
+    return existing_alias is not None

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -6,7 +6,7 @@ from nile.common import parse_information, run_command
 
 
 def declare(contract_name, network, alias=None, overriding_path=None):
-    """Deploy StarkNet smart contracts."""
+    """Declare StarkNet smart contracts."""
     logging.info(f"🚀 Declaring {contract_name}")
 
     output = run_command(contract_name, network, overriding_path, operation="declare")

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -1,9 +1,8 @@
 """Command to declare StarkNet smart contracts."""
 import logging
-import re
 
 from nile import deployments
-from nile.common import run_command, parse_information
+from nile.common import parse_information, run_command
 
 
 def declare(contract_name, network, alias=None, overriding_path=None):

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -1,0 +1,37 @@
+"""Command to deploy StarkNet smart contracts."""
+import logging
+import os
+import re
+import subprocess
+
+from nile import deployments
+from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
+
+
+def declare(contract_name, network, alias=None, overriding_path=None):
+    """Deploy StarkNet smart contracts."""
+    logging.info(f"🚀 Declaring {contract_name}")
+
+    command = ["starknet", "declare", "--contract", contract]
+
+    if network == "mainnet":
+        os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
+    elif network == "goerli":
+        os.environ["STARKNET_NETWORK"] = "alpha-goerli"
+    else:
+        command.append(f"--gateway_url={GATEWAYS.get(network)}")
+
+    output = subprocess.check_output(command)
+    address, tx_hash = parse_deployment(output)
+    logging.info(f"⏳ Declaration of {contract_name} successfully sent at {address}")
+    logging.info(f"🧾 Transaction hash: {tx_hash}")
+
+    declarations.register_class_hash(address, network, alias)
+    return address
+
+
+def parse_deployment(x):
+    """Extract information from deployment command."""
+    # address is 64, tx_hash is 64 chars long
+    address, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
+    return address, tx_hash

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 from nile import deployments
-from nile.common import run_command
+from nile.common import run_command, parse_information
 
 
 def declare(contract_name, network, alias=None, overriding_path=None):
@@ -11,16 +11,9 @@ def declare(contract_name, network, alias=None, overriding_path=None):
     logging.info(f"🚀 Declaring {contract_name}")
 
     output = run_command(contract_name, network, overriding_path, operation="declare")
-    class_hash, tx_hash = parse_declaration(output)
+    class_hash, tx_hash = parse_information(output)
     logging.info(f"⏳ Declaration of {contract_name} successfully sent at {class_hash}")
     logging.info(f"🧾 Transaction hash: {tx_hash}")
 
     deployments.register_class_hash(class_hash, network, alias)
     return class_hash
-
-
-def parse_declaration(x):
-    """Extract information from deployment command."""
-    # class_hash is 64, tx_hash is 64 chars long
-    class_hash, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
-    return class_hash, tx_hash

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -12,6 +12,10 @@ def declare(contract_name, network, alias=None, overriding_path=None):
     """Deploy StarkNet smart contracts."""
     logging.info(f"🚀 Declaring {contract_name}")
 
+    base_path = (
+        overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
+    )
+    contract = f"{base_path[0]}/{contract_name}.json"
     command = ["starknet", "declare", "--contract", contract]
 
     if network == "mainnet":

--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -30,7 +30,7 @@ def declare(contract_name, network, alias=None, overriding_path=None):
     logging.info(f"⏳ Declaration of {contract_name} successfully sent at {address}")
     logging.info(f"🧾 Transaction hash: {tx_hash}")
 
-    declarations.register_class_hash(address, network, alias)
+    deployments.register_class_hash(address, network, alias)
     return address
 
 

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -1,37 +1,21 @@
 """Command to deploy StarkNet smart contracts."""
 import logging
-import os
 import re
-import subprocess
 
 from nile import deployments
-from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, GATEWAYS
+from nile.common import run_command, BUILD_DIRECTORY, ABIS_DIRECTORY
 
 
 def deploy(contract_name, arguments, network, alias, overriding_path=None):
     """Deploy StarkNet smart contracts."""
     logging.info(f"🚀 Deploying {contract_name}")
-
     base_path = (
         overriding_path if overriding_path else (BUILD_DIRECTORY, ABIS_DIRECTORY)
     )
-    contract = f"{base_path[0]}/{contract_name}.json"
     abi = f"{base_path[1]}/{contract_name}.json"
 
-    command = ["starknet", "deploy", "--contract", contract]
+    output = run_command(contract_name, network, overriding_path, arguments=arguments)
 
-    if len(arguments) > 0:
-        command.append("--inputs")
-        command.extend([argument for argument in arguments])
-
-    if network == "mainnet":
-        os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
-    elif network == "goerli":
-        os.environ["STARKNET_NETWORK"] = "alpha-goerli"
-    else:
-        command.append(f"--gateway_url={GATEWAYS.get(network)}")
-
-    output = subprocess.check_output(command)
     address, tx_hash = parse_deployment(output)
     logging.info(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
     logging.info(f"🧾 Transaction hash: {tx_hash}")

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 from nile import deployments
-from nile.common import run_command, BUILD_DIRECTORY, ABIS_DIRECTORY
+from nile.common import run_command, BUILD_DIRECTORY, ABIS_DIRECTORY, parse_information
 
 
 def deploy(contract_name, arguments, network, alias, overriding_path=None):
@@ -16,16 +16,9 @@ def deploy(contract_name, arguments, network, alias, overriding_path=None):
 
     output = run_command(contract_name, network, overriding_path, arguments=arguments)
 
-    address, tx_hash = parse_deployment(output)
+    address, tx_hash = parse_information(output)
     logging.info(f"⏳ ️Deployment of {contract_name} successfully sent at {address}")
     logging.info(f"🧾 Transaction hash: {tx_hash}")
 
     deployments.register(address, abi, network, alias)
     return address, abi
-
-
-def parse_deployment(x):
-    """Extract information from deployment command."""
-    # address is 64, tx_hash is 64 chars long
-    address, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
-    return address, tx_hash

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -1,9 +1,8 @@
 """Command to deploy StarkNet smart contracts."""
 import logging
-import re
 
 from nile import deployments
-from nile.common import run_command, BUILD_DIRECTORY, ABIS_DIRECTORY, parse_information
+from nile.common import ABIS_DIRECTORY, BUILD_DIRECTORY, parse_information, run_command
 
 
 def deploy(contract_name, arguments, network, alias, overriding_path=None):

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -5,7 +5,7 @@ import subprocess
 from nile.common import NODE_FILENAME
 
 
-def node(host="127.0.0.1", port=5000):
+def node(host="127.0.0.1", port=5050):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -10,7 +10,10 @@ def node(host="127.0.0.1", port=5050):
     try:
         # Save host and port information to be used by other commands
         file = NODE_FILENAME
-        network = host
+        if host == "127.0.0.1":
+            network = "localhost"
+        else:
+            network = host
         gateway_url = f"http://{host}:{port}/"
         gateway = {network: gateway_url}
 

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -2,7 +2,7 @@
 import logging
 import os
 
-from nile.common import DEPLOYMENTS_FILENAME
+from nile.common import DECLARATIONS_FILENAME, DEPLOYMENTS_FILENAME
 
 
 def register(address, abi, network, alias):
@@ -20,6 +20,26 @@ def register(address, abi, network, alias):
             logging.info(f"📦 Registering {address} in {file}")
 
         fp.write(f"{address}:{abi}")
+        if alias is not None:
+            fp.write(f":{alias}")
+        fp.write("\n")
+
+
+def register_class_hash(address, network, alias):
+    """Register a new deployment."""
+    file = f"{network}.{DECLARATIONS_FILENAME}"
+
+    if alias is not None:
+        if exists(alias, network):
+            raise Exception(f"Alias {alias} already exists in {file}")
+
+    with open(file, "a") as fp:
+        if alias is not None:
+            logging.info(f"📦 Registering declaration as {alias} in {file}")
+        else:
+            logging.info(f"📦 Registering {address} in {file}")
+
+        fp.write(f"{address}")
         if alias is not None:
             fp.write(f":{alias}")
         fp.write("\n")

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -29,7 +29,7 @@ def register_class_hash(hash, network, alias):
     """Register a new deployment."""
     file = f"{network}.{DECLARATIONS_FILENAME}"
 
-    if hash_exists(hash, network):
+    if class_hash_exists(hash, network):
         raise Exception(f"Hash {hash[:6]}...{hash[-6:]} already exists in {file}")
 
     with open(file, "a") as fp:
@@ -50,7 +50,7 @@ def exists(identifier, network):
     return foo is not None
 
 
-def hash_exists(hash, network):
+def class_hash_exists(hash, network):
     """Return whether a class declaration exists or not."""
     if hash in load_class(hash, network):
         return True

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -29,10 +29,8 @@ def register_class_hash(hash, network, alias):
     """Register a new deployment."""
     file = f"{network}.{DECLARATIONS_FILENAME}"
 
-    if class_exists(hash, network, alias):
-        raise Exception(
-            f"Duplicate hash {hash[:6]}...{hash[-6:]} or alias {alias} in {file}"
-        )
+    if hash_exists(hash, network):
+        raise Exception(f"Hash {hash[:6]}...{hash[-6:]} already exists in {file}")
 
     with open(file, "a") as fp:
         if alias is not None:
@@ -52,14 +50,10 @@ def exists(identifier, network):
     return foo is not None
 
 
-def class_exists(hash, network, alias=None):
+def hash_exists(hash, network):
     """Return whether a class declaration exists or not."""
     if hash in load_class(hash, network):
         return True
-
-    if alias is not None:
-        foo = next(load_class(alias, network), None)
-        return foo is not None
 
 
 def load(identifier, network):

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -35,7 +35,7 @@ def register_class_hash(address, network, alias):
 
     with open(file, "a") as fp:
         if alias is not None:
-            logging.info(f"📦 Registering declaration as {alias} in {file}")
+            logging.info(f"📦 Registering {alias} in {file}")
         else:
             logging.info(f"📦 Registering {address} in {file}")
 

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -25,21 +25,22 @@ def register(address, abi, network, alias):
         fp.write("\n")
 
 
-def register_class_hash(address, network, alias):
+def register_class_hash(hash, network, alias):
     """Register a new deployment."""
     file = f"{network}.{DECLARATIONS_FILENAME}"
 
-    if alias is not None:
-        if exists(alias, network):
-            raise Exception(f"Alias {alias} already exists in {file}")
+    if class_exists(hash, network, alias):
+        raise Exception(
+            f"Duplicate hash {hash[:6]}...{hash[-6:]} or alias {alias} in {file}"
+        )
 
     with open(file, "a") as fp:
         if alias is not None:
             logging.info(f"📦 Registering {alias} in {file}")
         else:
-            logging.info(f"📦 Registering {address} in {file}")
+            logging.info(f"📦 Registering {hash} in {file}")
 
-        fp.write(f"{address}")
+        fp.write(f"{hash}")
         if alias is not None:
             fp.write(f":{alias}")
         fp.write("\n")
@@ -49,6 +50,16 @@ def exists(identifier, network):
     """Return whether a deployment exists or not."""
     foo = next(load(identifier, network), None)
     return foo is not None
+
+
+def class_exists(hash, network, alias=None):
+    """Return whether a class declaration exists or not."""
+    if hash in load_class(hash, network):
+        return True
+
+    if alias is not None:
+        foo = next(load_class(alias, network), None)
+        return foo is not None
 
 
 def load(identifier, network):
@@ -64,3 +75,18 @@ def load(identifier, network):
             identifiers = [x for x in [address] + alias]
             if identifier in identifiers:
                 yield address, abi
+
+
+def load_class(identifier, network):
+    """Load declaration class that matches an identifier (hash or alias)."""
+    file = f"{network}.{DECLARATIONS_FILENAME}"
+
+    if not os.path.exists(file):
+        return
+
+    with open(file) as fp:
+        for line in fp:
+            [hash, *alias] = line.strip().split(":")
+            identifiers = [x for x in [hash] + alias]
+            if identifier in identifiers:
+                yield hash

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -23,8 +23,6 @@ class NileRuntimeEnvironment:
 
     def declare(self, contract, alias=None, overriding_path=None):
         """Declare a smart contract class."""
-        if arguments is None:
-            arguments = []
         return declare(contract, self.network, alias)
 
     def deploy(self, contract, arguments=None, alias=None, overriding_path=None):

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -43,9 +43,13 @@ class NileRuntimeEnvironment:
             params = []
         return call_or_invoke(contract, "invoke", method, params, self.network, max_fee)
 
-    def get_deployment(self, contract):
+    def get_deployment(self, identifier):
         """Get a deployment by its identifier (address or alias)."""
-        return next(deployments.load(contract, self.network))
+        return next(deployments.load(identifier, self.network))
+
+    def get_declaration(self, identifier):
+        """Get a declared class by its identifier (class hash or alias)."""
+        return next(deployments.load_class(identifier, self.network))
 
     def get_or_deploy_account(self, signer):
         """Get or deploy an Account contract."""

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -20,23 +20,29 @@ class NileRuntimeEnvironment:
         """Compile a list of contracts."""
         return compile(contracts)
 
+    def declare(self, contract, overriding_path=None):
+        """Declare a smart contract class."""
+        if arguments is None:
+            arguments = []
+        return declare(contract, self.network, overriding_path)
+
     def deploy(self, contract, arguments=None, alias=None, overriding_path=None):
         """Deploy a smart contract."""
         if arguments is None:
             arguments = []
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
-    def call(self, contract, method, params=None):
+    def call(self, contract, method, params=None, max_fee=None):
         """Call a view function in a smart contract."""
         if params is None:
             params = []
         return call_or_invoke(contract, "call", method, params, self.network)
 
-    def invoke(self, contract, method, params=None):
+    def invoke(self, contract, method, params=None, max_fee=None):
         """Invoke a mutable function in a smart contract."""
         if params is None:
             params = []
-        return call_or_invoke(contract, "invoke", method, params, self.network)
+        return call_or_invoke(contract, "invoke", method, params, self.network, max_fee)
 
     def get_deployment(self, contract):
         """Get a deployment by its identifier (address or alias)."""

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -31,7 +31,7 @@ class NileRuntimeEnvironment:
             arguments = []
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
-    def call(self, contract, method, params=None, max_fee=None):
+    def call(self, contract, method, params=None):
         """Call a view function in a smart contract."""
         if params is None:
             params = []

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -37,11 +37,11 @@ class NileRuntimeEnvironment:
             params = []
         return call_or_invoke(contract, "call", method, params, self.network)
 
-    def invoke(self, contract, method, params=None, max_fee=None):
+    def invoke(self, contract, method, params=None):
         """Invoke a mutable function in a smart contract."""
         if params is None:
             params = []
-        return call_or_invoke(contract, "invoke", method, params, self.network, max_fee)
+        return call_or_invoke(contract, "invoke", method, params, self.network)
 
     def get_deployment(self, identifier):
         """Get a deployment by its identifier (address or alias)."""

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -4,6 +4,7 @@ from nile.core.account import Account
 from nile.core.call_or_invoke import call_or_invoke
 from nile.core.compile import compile
 from nile.core.deploy import deploy
+from nile.core.declare import declare
 from nile.core.plugins import get_installed_plugins, skip_click_exit
 
 
@@ -20,11 +21,11 @@ class NileRuntimeEnvironment:
         """Compile a list of contracts."""
         return compile(contracts)
 
-    def declare(self, contract, overriding_path=None):
+    def declare(self, contract, alias=None, overriding_path=None):
         """Declare a smart contract class."""
         if arguments is None:
             arguments = []
-        return declare(contract, self.network, overriding_path)
+        return declare(contract, self.network, alias)
 
     def deploy(self, contract, arguments=None, alias=None, overriding_path=None):
         """Deploy a smart contract."""

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -3,8 +3,8 @@ from nile import deployments
 from nile.core.account import Account
 from nile.core.call_or_invoke import call_or_invoke
 from nile.core.compile import compile
-from nile.core.deploy import deploy
 from nile.core.declare import declare
+from nile.core.deploy import deploy
 from nile.core.plugins import get_installed_plugins, skip_click_exit
 
 

--- a/src/nile/signer.py
+++ b/src/nile/signer.py
@@ -23,11 +23,11 @@ class Signer:
         """Sign a message hash."""
         return sign(msg_hash=message_hash, priv_key=self.private_key)
 
-    def sign_transaction(self, sender, calls, nonce, max_fee=0):
+    def sign_transaction(self, sender, calls, nonce, max_fee):
         """Sign a transaction for an Account."""
         (call_array, calldata) = from_call_to_call_array(calls)
         message_hash = get_transaction_hash(
-            int(sender, 16), call_array, calldata, nonce, max_fee
+            int(sender, 16), call_array, calldata, nonce, int(max_fee)
         )
         sig_r, sig_s = self.sign(message_hash)
         return (call_array, calldata, sig_r, sig_s)

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -101,7 +101,8 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
     with patch("nile.core.account.call_or_invoke") as mock_call:
         send_args = [contract_address, "method", [1, 2, 3]]
         nonce = 4
-        account.send(*send_args, nonce, max_fee=1)
+        max_fee = 1
+        account.send(*send_args, max_fee, nonce)
 
         # Check values are correctly passed to 'sign_transaction'
         account.signer.sign_transaction.assert_called_once_with(
@@ -111,6 +112,7 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
         # Check values are correctly passed to '__execute__'
         mock_call.assert_called_with(
             contract=account.address,
+            max_fee=str(max_fee),
             method="__execute__",
             network=NETWORK,
             params=[
@@ -121,6 +123,5 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
                 str(nonce),
             ],
             signature=[str(sig_r), str(sig_s)],
-            type="invoke",
-            max_fee=1,
+            type="invoke"
         )

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -74,7 +74,7 @@ def test_send_nonce_call(mock_call):
 
     # Instead of creating and populating a tmp .txt file, this uses the
     # deployed account address (contract_address) as the target
-    account.send(contract_address, "method", [1, 2, 3])
+    account.send(contract_address, "method", [1, 2, 3], max_fee=1)
 
     # 'call_or_invoke' is called twice ('get_nonce' and '__execute__')
     assert mock_call.call_count == 2
@@ -101,11 +101,11 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
     with patch("nile.core.account.call_or_invoke") as mock_call:
         send_args = [contract_address, "method", [1, 2, 3]]
         nonce = 4
-        account.send(*send_args, nonce)
+        account.send(*send_args, nonce, max_fee=1)
 
         # Check values are correctly passed to 'sign_transaction'
         account.signer.sign_transaction.assert_called_once_with(
-            calls=[send_args], nonce=nonce, sender=account.address
+            calls=[send_args], nonce=nonce, sender=account.address, max_fee=1
         )
 
         # Check values are correctly passed to '__execute__'
@@ -122,4 +122,5 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
             ],
             signature=[str(sig_r), str(sig_s)],
             type="invoke",
+            max_fee=1,
         )

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -123,5 +123,5 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
                 str(nonce),
             ],
             signature=[str(sig_r), str(sig_s)],
-            type="invoke"
+            type="invoke",
         )

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -30,9 +30,9 @@ def test_clean_already_clean(mock_os_remove, mock_shutil_rmtree):
 @pytest.mark.parametrize(
     "fname",
     [
-        f"127.0.0.1.{ACCOUNTS_FILENAME}",
-        f"127.0.0.1.{DEPLOYMENTS_FILENAME}",
-        f"127.0.0.1.{DECLARATIONS_FILENAME}",
+        f"localhost.{ACCOUNTS_FILENAME}",
+        f"localhost.{DEPLOYMENTS_FILENAME}",
+        f"localhost.{DECLARATIONS_FILENAME}",
     ],
 )
 @patch("nile.core.clean.shutil.rmtree")

--- a/tests/commands/test_clean.py
+++ b/tests/commands/test_clean.py
@@ -4,7 +4,12 @@ from unittest.mock import patch
 
 import pytest
 
-from nile.common import ACCOUNTS_FILENAME, BUILD_DIRECTORY, DEPLOYMENTS_FILENAME
+from nile.common import (
+    ACCOUNTS_FILENAME,
+    BUILD_DIRECTORY,
+    DECLARATIONS_FILENAME,
+    DEPLOYMENTS_FILENAME,
+)
 from nile.core.clean import clean
 
 
@@ -25,8 +30,9 @@ def test_clean_already_clean(mock_os_remove, mock_shutil_rmtree):
 @pytest.mark.parametrize(
     "fname",
     [
-        f"localhost.{ACCOUNTS_FILENAME}",
-        f"localhost.{DEPLOYMENTS_FILENAME}",
+        f"127.0.0.1.{ACCOUNTS_FILENAME}",
+        f"127.0.0.1.{DEPLOYMENTS_FILENAME}",
+        f"127.0.0.1.{DECLARATIONS_FILENAME}",
     ],
 )
 @patch("nile.core.clean.shutil.rmtree")

--- a/tests/commands/test_declare.py
+++ b/tests/commands/test_declare.py
@@ -1,0 +1,64 @@
+"""Tests for declare command."""
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from nile.core.declare import declare
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+CONTRACT = "contract"
+NETWORK = "goerli"
+ALIAS = "alias"
+PATH = "path"
+HASH = 111
+TX_HASH = 222
+
+
+@pytest.mark.parametrize(
+    "args, exp_command, exp_register",
+    [
+        (
+            [CONTRACT, NETWORK],  # args
+            [CONTRACT, NETWORK, None],  # expected command
+            [HASH, NETWORK, None],  # expected register
+        ),
+        (
+            [CONTRACT, NETWORK, ALIAS],  # args
+            [CONTRACT, NETWORK, None],  # expected command
+            [HASH, NETWORK, ALIAS],  # expected register
+        ),
+        (
+            [CONTRACT, NETWORK, ALIAS, PATH],  # args
+            [CONTRACT, NETWORK, PATH],  # expected command
+            [HASH, NETWORK, ALIAS],  # expected register
+        ),
+    ],
+)
+@patch("nile.core.declare.run_command")
+@patch("nile.core.declare.parse_information", return_value=[HASH, TX_HASH])
+@patch("nile.core.declare.deployments.register_class_hash")
+def test_declare(
+    mock_register, mock_parse, mock_command, caplog, args, exp_command, exp_register
+):
+    logging.getLogger().setLevel(logging.INFO)
+
+    # check return value
+    res = declare(*args)
+    assert res == HASH
+
+    # check internals
+    mock_command.assert_called_once_with(*exp_command, operation="declare")
+    mock_parse.assert_called_once()
+    mock_register.assert_called_once_with(*exp_register)
+
+    # check logs
+    assert f"🚀 Declaring {CONTRACT}" in caplog.text
+    assert f"⏳ Declaration of {CONTRACT} successfully sent at {HASH}" in caplog.text
+    assert f"🧾 Transaction hash: {TX_HASH}" in caplog.text

--- a/tests/commands/test_declare.py
+++ b/tests/commands/test_declare.py
@@ -17,6 +17,7 @@ CONTRACT = "contract"
 NETWORK = "goerli"
 ALIAS = "alias"
 PATH = "path"
+RUN_OUTPUT = b'output'
 HASH = 111
 TX_HASH = 222
 
@@ -41,11 +42,11 @@ TX_HASH = 222
         ),
     ],
 )
-@patch("nile.core.declare.run_command")
+@patch("nile.core.declare.run_command", return_value=RUN_OUTPUT)
 @patch("nile.core.declare.parse_information", return_value=[HASH, TX_HASH])
 @patch("nile.core.declare.deployments.register_class_hash")
 def test_declare(
-    mock_register, mock_parse, mock_command, caplog, args, exp_command, exp_register
+    mock_register, mock_parse, mock_run_cmd, caplog, args, exp_command, exp_register
 ):
     logging.getLogger().setLevel(logging.INFO)
 
@@ -54,8 +55,8 @@ def test_declare(
     assert res == HASH
 
     # check internals
-    mock_command.assert_called_once_with(*exp_command, operation="declare")
-    mock_parse.assert_called_once()
+    mock_run_cmd.assert_called_once_with(*exp_command, operation="declare")
+    mock_parse.assert_called_once_with(RUN_OUTPUT)
     mock_register.assert_called_once_with(*exp_register)
 
     # check logs

--- a/tests/commands/test_declare.py
+++ b/tests/commands/test_declare.py
@@ -17,7 +17,7 @@ CONTRACT = "contract"
 NETWORK = "goerli"
 ALIAS = "alias"
 PATH = "path"
-RUN_OUTPUT = b'output'
+RUN_OUTPUT = b"output"
 HASH = 111
 TX_HASH = 222
 

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -4,7 +4,8 @@ from unittest.mock import patch
 
 import pytest
 
-from nile.core.deploy import deploy, ABIS_DIRECTORY, BUILD_DIRECTORY
+from nile.core.deploy import ABIS_DIRECTORY, BUILD_DIRECTORY, deploy
+
 
 @pytest.fixture(autouse=True)
 def tmp_working_dir(monkeypatch, tmp_path):
@@ -18,7 +19,7 @@ ALIAS = "alias"
 ABI = f"{ABIS_DIRECTORY}/{CONTRACT}.json"
 BASE_PATH = (BUILD_DIRECTORY, ABIS_DIRECTORY)
 PATH_OVERRIDE = ("artifacts2", ABIS_DIRECTORY)
-RUN_OUTPUT = b'output'
+RUN_OUTPUT = b"output"
 ARGS = [1, 2, 3]
 ADDRESS = 999
 TX_HASH = 222
@@ -56,4 +57,3 @@ def test_declare(mock_register, mock_parse, mock_run_cmd, caplog, args, exp_comm
     assert f"🚀 Deploying {CONTRACT}" in caplog.text
     assert f"⏳ ️Deployment of {CONTRACT} successfully sent at {ADDRESS}" in caplog.text
     assert f"🧾 Transaction hash: {TX_HASH}" in caplog.text
-

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -1,4 +1,4 @@
-"""Tests for declare command."""
+"""Tests for deploy command."""
 import logging
 from unittest.mock import patch
 
@@ -41,7 +41,7 @@ TX_HASH = 222
 @patch("nile.core.deploy.run_command", return_value=RUN_OUTPUT)
 @patch("nile.core.deploy.parse_information", return_value=[ADDRESS, TX_HASH])
 @patch("nile.core.deploy.deployments.register")
-def test_declare(mock_register, mock_parse, mock_run_cmd, caplog, args, exp_command):
+def test_deploy(mock_register, mock_parse, mock_run_cmd, caplog, args, exp_command):
     logging.getLogger().setLevel(logging.INFO)
 
     # check return values

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -1,0 +1,59 @@
+"""Tests for declare command."""
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from nile.core.deploy import deploy, ABIS_DIRECTORY, BUILD_DIRECTORY
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+CONTRACT = "contract"
+NETWORK = "goerli"
+ALIAS = "alias"
+ABI = f"{ABIS_DIRECTORY}/{CONTRACT}.json"
+BASE_PATH = (BUILD_DIRECTORY, ABIS_DIRECTORY)
+PATH_OVERRIDE = ("artifacts2", ABIS_DIRECTORY)
+RUN_OUTPUT = b'output'
+ARGS = [1, 2, 3]
+ADDRESS = 999
+TX_HASH = 222
+
+
+@pytest.mark.parametrize(
+    "args, exp_command",
+    [
+        (
+            [CONTRACT, ARGS, NETWORK, ALIAS],  # args
+            [CONTRACT, NETWORK, None],  # expected command
+        ),
+        (
+            [CONTRACT, ARGS, NETWORK, ALIAS, PATH_OVERRIDE],  # args
+            [CONTRACT, NETWORK, PATH_OVERRIDE],  # expected command
+        ),
+    ],
+)
+@patch("nile.core.deploy.run_command", return_value=RUN_OUTPUT)
+@patch("nile.core.deploy.parse_information", return_value=[ADDRESS, TX_HASH])
+@patch("nile.core.deploy.deployments.register")
+def test_declare(mock_register, mock_parse, mock_run_cmd, caplog, args, exp_command):
+    logging.getLogger().setLevel(logging.INFO)
+
+    # check return values
+    res = deploy(*args)
+    assert res == (ADDRESS, ABI)
+
+    # check internals
+    mock_run_cmd.assert_called_once_with(*exp_command, arguments=ARGS)
+    mock_parse.assert_called_once_with(RUN_OUTPUT)
+    mock_register.assert_called_once_with(ADDRESS, ABI, NETWORK, ALIAS)
+
+    # check logs
+    assert f"🚀 Deploying {CONTRACT}" in caplog.text
+    assert f"⏳ ️Deployment of {CONTRACT} successfully sent at {ADDRESS}" in caplog.text
+    assert f"🧾 Transaction hash: {TX_HASH}" in caplog.text
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,7 +118,7 @@ def test_compile(args, expected):
 )
 def test_node(args, expected):
     # Node life
-    seconds = 8
+    seconds = 15
 
     if args == []:
         host, port = "127.0.0.1", 5050

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,7 +107,7 @@ def test_compile(args, expected):
 @pytest.mark.parametrize(
     "args, expected",
     [
-        ([], "http://127.0.0.1:5000/"),
+        ([], "http://127.0.0.1:5050/"),
         (["--host", "localhost", "--port", "5001"], "http://localhost:5001/"),
     ],
 )
@@ -121,7 +121,7 @@ def test_node(args, expected):
     seconds = 8
 
     if args == []:
-        host, port = "127.0.0.1", 5000
+        host, port = "127.0.0.1", 5050
     else:
         host, port = args[1], int(args[3])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,11 @@ def test_node(args, expected):
     else:
         host, port = args[1], int(args[3])
 
-    network = host
+    if network == "127.0.0.1":
+        network = "localhost"
+    else:
+        network = host
+
     gateway_url = f"http://{host}:{port}/"
 
     # Spawn process to start StarkNet local network with specified port

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,7 +125,7 @@ def test_node(args, expected):
     else:
         host, port = args[1], int(args[3])
 
-    if network == "127.0.0.1":
+    if host == "127.0.0.1":
         network = "localhost"
     else:
         network = host

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -7,7 +7,7 @@ A high-level synchronization check between the Account artifacts and Signer modu
 import asyncio
 
 import pytest
-from starkware.starknet.services.api.contract_definition import ContractDefinition
+from starkware.starknet.services.api.contract_class import ContractClass
 from starkware.starknet.testing.starknet import Starknet
 
 from nile.signer import Signer
@@ -17,7 +17,7 @@ SIGNER = Signer(12345678987654321)
 
 def get_account_definition():
     with open("src/nile/artifacts/Account.json", "r") as fp:
-        return ContractDefinition.loads(fp.read())
+        return ContractClass.loads(fp.read())
 
 
 async def send_transaction(

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -56,7 +56,8 @@ def event_loop():
 async def test_execute():
     starknet = await Starknet.empty()
     account = await starknet.deploy(
-        contract_def=get_account_definition(), constructor_calldata=[SIGNER.public_key]
+        contract_class=get_account_definition(),
+        constructor_calldata=[SIGNER.public_key],
     )
     contract = await starknet.deploy(
         "tests/resources/contracts/contract.cairo",

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ passenv =
 extras =
     testing
 deps =
-    werkzeug==2.0.0
     starknet-devnet
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ passenv =
 extras =
     testing
 deps =
+    cairo-lang==0.9.0
     starknet-devnet
     # See https://github.com/starkware-libs/cairo-lang/issues/52
     marshmallow-dataclass==8.5.3


### PR DESCRIPTION
Supercedes #131, fixes #130 and #96.

This PR proposes to:
- add `max_fee` to the tx flow
- include `declare` command in CLI and NRE
  - tracks declarations in a `declarations.txt`
- update cairo-lang to v.0.9.0 in tox dependencies
- update signer to use `contract_class` instead of `contract_def`
- fix host in `clean`