### PR TITLE
add --seed option to nile node command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,15 @@ This command creates the project directory structure and installs `cairo-lang`, 
 Run a local [`starknet-devnet`](https://github.com/Shard-Labs/starknet-devnet/) node:
 
 ```text
-nile node [--host HOST] [--port PORT] [--lite_mode]
+nile node [--host HOST] [--port PORT] [--seed SEED] [--lite_mode]
 
 optional arguments:
 --host HOST         Specify the address to listen at; defaults to
                     127.0.0.1 (use the address the program outputs on
                     start)
 --port PORT         Specify the port to listen at; defaults to 5050
+--seed SEED         Specify the seed for randomness of accounts to be
+                    deployed
 --lite-mode         Applies all lite-mode optimizations by disabling
                     features such as block hash and deploy hash
                     calculation

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -195,7 +195,8 @@ def clean():
 @cli.command()
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=5050)
-def node(host, port):
+@click.option("--seed", type=int)
+def node(host, port, seed):
     """Start StarkNet local network.
 
     $ nile node
@@ -203,8 +204,11 @@ def node(host, port):
 
     $ nile node --host HOST --port 5001
       Start StarkNet network on address HOST listening at port 5001
+
+    $ nile node --seed SEED
+      Start StarkNet local network with seed SEED
     """
-    node_command(host, port)
+    node_command(host, port, seed)
 
 
 @cli.command()

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -5,7 +5,7 @@ import subprocess
 from nile.common import NODE_FILENAME
 
 
-def node(host="127.0.0.1", port=5050):
+def node(host="127.0.0.1", port=5050, seed=None):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands
@@ -20,8 +20,14 @@ def node(host="127.0.0.1", port=5050):
         with open(file, "w+") as f:
             json.dump(gateway, f)
 
+        command = ["starknet-devnet", "--host", host, "--port", str(port)]
+
+        if seed is not None:
+            command.append("--seed")
+            command.append(str(seed))
+
         # Start network
-        subprocess.check_call(["starknet-devnet", "--host", host, "--port", str(port)])
+        subprocess.check_call(command)
 
     except FileNotFoundError:
         print("")

--- a/tests/commands/test_node.py
+++ b/tests/commands/test_node.py
@@ -8,6 +8,7 @@ from nile.core.node import node
 
 HOST = "127.0.0.1"
 PORT = "5050"
+SEED = "123"
 LITE = "--lite-mode"
 
 
@@ -20,17 +21,22 @@ def tmp_working_dir(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "args",
     [
-        ([]),
-        ([HOST, PORT]),
-        ([HOST, PORT, LITE]),
+        ({}),
+        ({"seed": SEED}),
+        ({"lite_mode": LITE}),
+        ({"host": HOST, "port": PORT}),
+        ({"host": HOST, "port": PORT, "seed": SEED, "lite_mode": LITE}),
     ],
 )
 @patch("nile.core.node.subprocess.check_call")
 def test_node_call(mock_subprocess, args):
-    node(*args)
+    node(**args)
 
     command = ["starknet-devnet", "--host", HOST, "--port", PORT]
-    if LITE in args:
+    if "seed" in args:
+        command.append("--seed")
+        command.append(SEED)
+    if "lite_mode" in args:
         command.append(LITE)
     mock_subprocess.assert_called_once_with(command)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 import json
 import shutil
 import sys
+import itertools
 from multiprocessing import Process
 from os import getpid, kill
 from pathlib import Path
@@ -104,11 +105,35 @@ def test_compile(args, expected):
     assert {f.name for f in build_dir.glob("*.json")} == expected
 
 
+@pytest.mark.xfail(
+    sys.version_info >= (3, 10),
+    reason="Issue in cairo-lang. "
+    "See https://github.com/starkware-libs/cairo-lang/issues/27",
+)
+@patch("nile.core.node.subprocess")
+def test_node_forwards_args(mock_subprocess):
+    args = [
+        "--host",
+        "localhost",
+        "--port",
+        "5001",
+        "--seed",
+        "1234",
+    ]
+
+    result = CliRunner().invoke(cli, ["node", *args])
+    assert result.exit_code == 0
+
+    expected = ["starknet-devnet", *args]
+    mock_subprocess.check_call.assert_called_once_with(expected)
+
+
 @pytest.mark.parametrize(
-    "args, expected",
+    "opts, expected",
     [
-        ([], "http://127.0.0.1:5050/"),
-        (["--host", "localhost", "--port", "5001"], "http://localhost:5001/"),
+        ({}, "http://127.0.0.1:5050/"),
+        ({"--host": "localhost", "--port": "5001"}, "http://localhost:5001/"),
+        ({"--seed": "1234"}, "http://127.0.0.1:5050/"),
     ],
 )
 @pytest.mark.xfail(
@@ -116,14 +141,12 @@ def test_compile(args, expected):
     reason="Issue in cairo-lang. "
     "See https://github.com/starkware-libs/cairo-lang/issues/27",
 )
-def test_node(args, expected):
+def test_node_runs_gateway(opts, expected):
     # Node life
     seconds = 15
 
-    if args == []:
-        host, port = "127.0.0.1", 5050
-    else:
-        host, port = args[1], int(args[3])
+    host = opts.get("--host", "127.0.0.1")
+    port = opts.get("--port", "5050")
 
     if host == "127.0.0.1":
         network = "localhost"
@@ -131,6 +154,11 @@ def test_node(args, expected):
         network = host
 
     gateway_url = f"http://{host}:{port}/"
+
+    # Convert opts to arg list -
+    #   { "--host": "localhost", "--port":  "5001" } =>
+    #   [ "--host", "localhost", "--port", "5001" ]
+    args = itertools.chain.from_iterable(opts.items())
 
     # Spawn process to start StarkNet local network with specified port
     # i.e. $ nile node --host localhost --port 5001
@@ -147,7 +175,6 @@ def test_node(args, expected):
     with open(file, "r") as f:
         gateway = json.load(f)
     assert gateway.get(network) == expected
-
 
 @pytest.mark.parametrize(
     "args",


### PR DESCRIPTION
Fixes #148. Adding the `--seed` options to `nile node` allows callers to get deterministic pre-funded accounts

Found myself wanting this feature so thought I would propose in the form of a PR. If this is something you might consider I could work on tests for it. If not, no hard feelings. 