### PR TITLE
Fix passing optional args in `_compile_contract`

### DIFF
--- a/src/nile/core/compile.py
+++ b/src/nile/core/compile.py
@@ -67,10 +67,10 @@ def _compile_contract(
     """
 
     if account_contract or filename.endswith("Account"):
-        cmd = cmd + "--account_contract"
+        cmd = cmd + "\n--account_contract"
 
     if disable_hint_validation:
-        cmd = cmd + "--disable_hint_validation"
+        cmd = cmd + "\n--disable_hint_validation"
 
     process = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
     process.communicate()

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -84,20 +84,18 @@ def test__compile_contract(mock_subprocess, is_acct, disable_hint):
     path = f"path/to/{contract_name}.cairo"
 
     _compile_contract(
-        path=path,
-        account_contract=is_acct,
-        disable_hint_validation=disable_hint
+        path=path, account_contract=is_acct, disable_hint_validation=disable_hint
     )
 
     expected = [
-            "starknet-compile",
-            path,
-            f"--cairo_path={CONTRACTS_DIRECTORY}",
-            "--output",
-            f"artifacts/{contract_name}.json",
-            "--abi",
-            f"artifacts/abis/{contract_name}.json",
-        ]
+        "starknet-compile",
+        path,
+        f"--cairo_path={CONTRACTS_DIRECTORY}",
+        "--output",
+        f"artifacts/{contract_name}.json",
+        "--abi",
+        f"artifacts/abis/{contract_name}.json",
+    ]
 
     if is_acct:
         expected.append("--account_contract")

--- a/tests/commands/test_compile.py
+++ b/tests/commands/test_compile.py
@@ -67,50 +67,46 @@ def test_compile_failure_feedback(mock__compile_contract, caplog):
     assert "Failed" in caplog.text
 
 
-def test__compile_contract(mock_subprocess):
-    contract_name_root = "contract"
-    path = f"path/to/{contract_name_root}.cairo"
-
+@pytest.mark.parametrize(
+    "is_acct, disable_hint",
+    [
+        (False, False),
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test__compile_contract(mock_subprocess, is_acct, disable_hint):
     mock_process = Mock()
     mock_subprocess.Popen.return_value = mock_process
 
-    _compile_contract(path)
+    contract_name = "contract"
+    path = f"path/to/{contract_name}.cairo"
 
-    mock_subprocess.Popen.assert_called_once_with(
-        [
-            "starknet-compile",
-            path,
-            f"--cairo_path={CONTRACTS_DIRECTORY}",
-            "--output",
-            f"artifacts/{contract_name_root}.json",
-            "--abi",
-            f"artifacts/abis/{contract_name_root}.json",
-        ],
-        stdout=mock_subprocess.PIPE,
+    _compile_contract(
+        path=path,
+        account_contract=is_acct,
+        disable_hint_validation=disable_hint
     )
-    mock_process.communicate.assert_called_once()
 
-
-def test__compile_account_contract(mock_subprocess):
-    contract_name_root = "mock_account"
-    path = f"path/to/{contract_name_root}.cairo"
-
-    mock_process = Mock()
-    mock_subprocess.Popen.return_value = mock_process
-
-    _compile_contract(path, account_contract="--account_contract")
-
-    mock_subprocess.Popen.assert_called_once_with(
-        [
+    expected = [
             "starknet-compile",
             path,
             f"--cairo_path={CONTRACTS_DIRECTORY}",
             "--output",
-            f"artifacts/{contract_name_root}.json",
+            f"artifacts/{contract_name}.json",
             "--abi",
-            f"artifacts/abis/{contract_name_root}.json",
-            "--account_contract",
-        ],
+            f"artifacts/abis/{contract_name}.json",
+        ]
+
+    if is_acct:
+        expected.append("--account_contract")
+
+    if disable_hint:
+        expected.append("--disable_hint_validation")
+
+    mock_subprocess.Popen.assert_called_once_with(
+        expected,
         stdout=mock_subprocess.PIPE,
     )
     mock_process.communicate.assert_called_once()
@@ -147,31 +143,6 @@ def test__compile_auto_account_flag(mock_subprocess, contract_name, flag):
 
     mock_subprocess.Popen.assert_called_once_with(
         returned_subprocess,
-        stdout=mock_subprocess.PIPE,
-    )
-    mock_process.communicate.assert_called_once()
-
-
-def test__compile_contract_without_hint_validation(mock_subprocess):
-    contract_name_root = "contract_with_unwhitelisted_hints"
-    path = f"path/to/{contract_name_root}.cairo"
-
-    mock_process = Mock()
-    mock_subprocess.Popen.return_value = mock_process
-
-    _compile_contract(path, disable_hint_validation=True)
-
-    mock_subprocess.Popen.assert_called_once_with(
-        [
-            "starknet-compile",
-            path,
-            f"--cairo_path={CONTRACTS_DIRECTORY}",
-            "--output",
-            f"artifacts/{contract_name_root}.json",
-            "--abi",
-            f"artifacts/abis/{contract_name_root}.json",
-            "--disable_hint_validation",
-        ],
         stdout=mock_subprocess.PIPE,
     )
     mock_process.communicate.assert_called_once()


### PR DESCRIPTION
When executing `nile compile` with the optional `--account_contract` and `--disable_hint_validation` flags, `_compile_contract` concatenated the flags i.e. `--account_contract--disable_hint_validation`.

Resolves #149.