### PR TITLE
Sanitize call/invoke params

### DIFF
--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -58,7 +58,7 @@ def run_command(
 
     if arguments:
         command.append("--inputs")
-        command.extend([argument for argument in arguments])
+        command.extend(prepare_params(arguments))
 
     if network == "mainnet":
         os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
@@ -77,3 +77,16 @@ def parse_information(x):
     # address is 64, tx_hash is 64 chars long
     address, tx_hash = re.findall("0x[\\da-f]{1,64}", str(x))
     return address, tx_hash
+
+
+def stringify(x):
+    if isinstance(x, list):
+        return [stringify(y) for y in x]
+    else:
+        return str(x)
+
+
+def prepare_params(params):
+    if params is None:
+        params = []
+    return stringify(params)

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -80,6 +80,7 @@ def parse_information(x):
 
 
 def stringify(x):
+    """Recursively convert list elements to strings."""
     if isinstance(x, list):
         return [stringify(y) for y in x]
     else:
@@ -87,6 +88,7 @@ def stringify(x):
 
 
 def prepare_params(params):
+    """Sanitize call, invoke, and deploy parameters."""
     if params is None:
         params = []
     return stringify(params)

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -66,7 +66,7 @@ class Account:
 
         if nonce is None:
             nonce = int(
-                call_or_invoke(self.address, "call", "get_nonce", [], self.network)
+                call_or_invoke(self.address, "call", "get_nonce", [], self.network)[0]
             )
 
         if max_fee is None:
@@ -80,11 +80,11 @@ class Account:
         )
 
         params = []
-        params.append(str(len(call_array)))
-        params.extend([str(elem) for sublist in call_array for elem in sublist])
-        params.append(str(len(calldata)))
-        params.extend([str(param) for param in calldata])
-        params.append(str(nonce))
+        params.append(len(call_array))
+        params.extend(*call_array)
+        params.append(len(calldata))
+        params.extend(calldata)
+        params.append(nonce)
 
         return call_or_invoke(
             contract=self.address,

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 from nile import deployments
-from nile.common import GATEWAYS
+from nile.common import GATEWAYS, prepare_params
 
 
 def call_or_invoke(
@@ -32,6 +32,8 @@ def call_or_invoke(
         gateway_prefix = "feeder_gateway" if type == "call" else "gateway"
         command.append(f"--{gateway_prefix}_url={GATEWAYS.get(network)}")
 
+    params = prepare_params(params)
+
     if len(params) > 0:
         command.append("--inputs")
         command.extend(params)
@@ -47,7 +49,7 @@ def call_or_invoke(
     command.append("--no_wallet")
 
     try:
-        return subprocess.check_output(command).strip().decode("utf-8")
+        return subprocess.check_output(command).strip().decode("utf-8").split()
     except subprocess.CalledProcessError:
         p = subprocess.Popen(command, stderr=subprocess.PIPE)
         _, error = p.communicate()

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -27,20 +27,14 @@ class NileRuntimeEnvironment:
 
     def deploy(self, contract, arguments=None, alias=None, overriding_path=None):
         """Deploy a smart contract."""
-        if arguments is None:
-            arguments = []
         return deploy(contract, arguments, self.network, alias, overriding_path)
 
     def call(self, contract, method, params=None):
         """Call a view function in a smart contract."""
-        if params is None:
-            params = []
         return call_or_invoke(contract, "call", method, params, self.network)
 
     def invoke(self, contract, method, params=None):
         """Invoke a mutable function in a smart contract."""
-        if params is None:
-            params = []
         return call_or_invoke(contract, "invoke", method, params, self.network)
 
     def get_deployment(self, identifier):

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -99,7 +99,7 @@ def test_send_nonce_call(mock_call):
     "callarray, calldata",
     # The following callarray and calldata args tests the Account's list comprehensions
     # ensuring they're set to strings and passed correctly
-    [([['111']], []), ([['111', '222']], ['333', '444', '555'])],
+    [([["111"]], []), ([["111", "222"]], ["333", "444", "555"])],
 )
 def test_send_sign_transaction_and_execute(callarray, calldata):
     account = Account(KEY, NETWORK)

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -99,7 +99,7 @@ def test_send_nonce_call(mock_call):
     "callarray, calldata",
     # The following callarray and calldata args tests the Account's list comprehensions
     # ensuring they're set to strings and passed correctly
-    [([[111]], []), ([[111, 222]], [333, 444, 555])],
+    [([['111']], []), ([['111', '222']], ['333', '444', '555'])],
 )
 def test_send_sign_transaction_and_execute(callarray, calldata):
     account = Account(KEY, NETWORK)
@@ -128,11 +128,11 @@ def test_send_sign_transaction_and_execute(callarray, calldata):
             method="__execute__",
             network=NETWORK,
             params=[
-                str(len(callarray)),
+                len(callarray),
                 *(str(elem) for sublist in callarray for elem in sublist),
-                str(len(calldata)),
+                len(calldata),
                 *(str(param) for param in calldata),
-                str(nonce),
+                nonce,
             ],
             signature=[str(sig_r), str(sig_s)],
             type="invoke",

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,7 +8,7 @@ from nile.common import BUILD_DIRECTORY, run_command
 CONTRACT = "contract"
 OPERATION = "invoke"
 NETWORK = "goerli"
-ARGS = [1, 2, 3]
+ARGS = ['1', '2', '3']
 
 
 @pytest.mark.parametrize("operation", ["invoke", "call"])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,7 +8,7 @@ from nile.common import BUILD_DIRECTORY, run_command
 CONTRACT = "contract"
 OPERATION = "invoke"
 NETWORK = "goerli"
-ARGS = ['1', '2', '3']
+ARGS = ["1", "2", "3"]
 
 
 @pytest.mark.parametrize("operation", ["invoke", "call"])

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,14 +1,17 @@
-"""Tests for deploy command."""
+"""Tests for common library."""
 from unittest.mock import patch
 
 import pytest
 
-from nile.common import BUILD_DIRECTORY, run_command
+from nile.common import BUILD_DIRECTORY, prepare_params, run_command, stringify
 
 CONTRACT = "contract"
 OPERATION = "invoke"
 NETWORK = "goerli"
 ARGS = ["1", "2", "3"]
+LIST1 = [1, 2, 3]
+LIST2 = [1, 2, 3, [4, 5, 6]]
+LIST3 = [1, 2, 3, [4, 5, 6, [7, 8, 9]]]
 
 
 @pytest.mark.parametrize("operation", ["invoke", "call"])
@@ -30,3 +33,27 @@ def test_run_command(mock_subprocess, operation):
             "--no_wallet",
         ]
     )
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], []),
+        ([LIST1], [["1", "2", "3"]]),
+        ([LIST2], [["1", "2", "3", ["4", "5", "6"]]]),
+        ([LIST3], [["1", "2", "3", ["4", "5", "6", ["7", "8", "9"]]]]),
+    ],
+)
+def test_stringify(args, expected):
+    assert stringify(args) == expected
+
+
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], []),
+        ([LIST1], [["1", "2", "3"]]),
+    ],
+)
+def test_prepare_params(args, expected):
+    assert prepare_params(args) == expected


### PR DESCRIPTION
This PR aims to sanitize parameters sent to `nre` functions like `deploy`, `call`, and `invoke` as well as `account.send`. For this, it recursively converts parameters to strings in `common.run_command` and `call_or_invoke`.

It also `.split()`s the return value of `call` and `invoke` operations to better parse return values (e.g. `uint`)