### PR TITLE
Fix CLI param handling

### DIFF
--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -80,7 +80,7 @@ def parse_information(x):
 
 
 def stringify(x):
-    """Recursively convert list elements to strings."""
+    """Recursively convert list or tuple elements to strings."""
     if isinstance(x, list) or isinstance(x, tuple):
         return [stringify(y) for y in x]
     else:

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -81,7 +81,7 @@ def parse_information(x):
 
 def stringify(x):
     """Recursively convert list elements to strings."""
-    if isinstance(x, list):
+    if isinstance(x, list) or isinstance(x, tuple):
         return [stringify(y) for y in x]
     else:
         return str(x)

--- a/src/nile/core/call_or_invoke.py
+++ b/src/nile/core/call_or_invoke.py
@@ -49,7 +49,7 @@ def call_or_invoke(
     command.append("--no_wallet")
 
     try:
-        return subprocess.check_output(command).strip().decode("utf-8").split()
+        return subprocess.check_output(command).strip().decode("utf-8")
     except subprocess.CalledProcessError:
         p = subprocess.Popen(command, stderr=subprocess.PIPE)
         _, error = p.communicate()

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -31,7 +31,9 @@ class NileRuntimeEnvironment:
 
     def call(self, contract, method, params=None):
         """Call a view function in a smart contract."""
-        return call_or_invoke(contract, "call", method, params, self.network)
+        return str(
+            call_or_invoke(contract, "call", method, params, self.network)
+        ).split()
 
     def invoke(self, contract, method, params=None):
         """Invoke a mutable function in a smart contract."""


### PR DESCRIPTION
This PR proposes to fix the CLI's `call` and `invoke`. This includes:
- applying `stringify` to tuples
  - cli.py passes args as tuples; therefore, `stringify` did not handle these args correctly
- moving the string `split` to the NRE's specific `call` method
  - otherwise, the CLI output returned a list of strings i.e. `["0"]`

Resolves #167.