### PR TITLE
Update invoke to execute

### DIFF
--- a/src/nile/base_project/tests/test_contract.py
+++ b/src/nile/base_project/tests/test_contract.py
@@ -23,8 +23,8 @@ async def test_increase_balance():
     )
 
     # Invoke increase_balance() twice.
-    await contract.increase_balance(amount=10).invoke()
-    await contract.increase_balance(amount=20).invoke()
+    await contract.increase_balance(amount=10).execute()
+    await contract.increase_balance(amount=20).execute()
 
     # Check the result of get_balance().
     execution_info = await contract.get_balance().call()


### PR DESCRIPTION
Fixing the NotImplementedError raised by using invoke in the StarknetContractFunctionInvocation by using execute instead, as the cairo-lang repo recommends.