### PR TITLE
Devnet predeployed accounts

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -19,6 +19,8 @@ from nile.core.test import test as test_command
 from nile.core.version import version as version_command
 from nile.utils.debug import debug as debug_command
 from nile.utils.get_accounts import get_accounts as get_accounts_command
+from nile.devnet import get_predeployed_accounts as get_predeployed_accounts_command
+
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
@@ -234,9 +236,13 @@ def debug(tx_hash, network, contracts_file):
 
 @cli.command()
 @network_option
-def get_accounts(network):
+@click.option("--predeployed/--registered", default=False)
+def get_accounts(network, predeployed):
     """Retrieve and manage deployed accounts."""
-    return get_accounts_command(network)
+    if not predeployed:
+        return get_accounts_command(network)
+    else:
+        return get_predeployed_accounts_command(network)
 
 
 cli = load_plugins(cli)

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -17,10 +17,9 @@ from nile.core.plugins import load_plugins
 from nile.core.run import run as run_command
 from nile.core.test import test as test_command
 from nile.core.version import version as version_command
+from nile.devnet import get_predeployed_accounts as get_predeployed_accounts_command
 from nile.utils.debug import debug as debug_command
 from nile.utils.get_accounts import get_accounts as get_accounts_command
-from nile.devnet import get_predeployed_accounts as get_predeployed_accounts_command
-
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -15,7 +15,7 @@ NODE_FILENAME = "node.json"
 RETRY_AFTER_SECONDS = 30
 
 
-def _get_gateway():
+def get_gateway():
     """Get the StarkNet node details."""
     try:
         with open(NODE_FILENAME, "r") as f:
@@ -27,7 +27,7 @@ def _get_gateway():
             f.write('{"localhost": "http://127.0.0.1:5050/"}')
 
 
-GATEWAYS = _get_gateway()
+GATEWAYS = get_gateway()
 
 
 def get_all_contracts(ext=None, directory=None):

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -28,7 +28,7 @@ class Account:
                 self.alias = signer
             else:
                 self.signer = Signer(int(signer, 16))
-                self.alias = predeployed_info['alias']
+                self.alias = predeployed_info["alias"]
 
             self.network = network
         except KeyError:
@@ -40,8 +40,8 @@ class Account:
             return
 
         if predeployed_info is not None:
-            self.address = predeployed_info['address']
-            self.index = predeployed_info['index']
+            self.address = predeployed_info["address"]
+            self.index = predeployed_info["index"]
         elif accounts.exists(str(self.signer.public_key), network):
             signer_data = next(accounts.load(str(self.signer.public_key), network))
             self.address = signer_data["address"]

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -20,11 +20,16 @@ load_dotenv()
 class Account:
     """Account contract abstraction."""
 
-    def __init__(self, signer, network):
+    def __init__(self, signer, network, predeployed_info=None):
         """Get or deploy an Account contract for the given private key."""
         try:
-            self.signer = Signer(int(os.environ[signer]))
-            self.alias = signer
+            if predeployed_info is None:
+                self.signer = Signer(int(os.environ[signer]))
+                self.alias = signer
+            else:
+                self.signer = Signer(int(signer, 16))
+                self.alias = predeployed_info['alias']
+
             self.network = network
         except KeyError:
             logging.error(
@@ -34,7 +39,10 @@ class Account:
             )
             return
 
-        if accounts.exists(str(self.signer.public_key), network):
+        if predeployed_info is not None:
+            self.address = predeployed_info['address']
+            self.index = predeployed_info['index']
+        elif accounts.exists(str(self.signer.public_key), network):
             signer_data = next(accounts.load(str(self.signer.public_key), network))
             self.address = signer_data["address"]
             self.index = signer_data["index"]

--- a/src/nile/devnet.py
+++ b/src/nile/devnet.py
@@ -1,11 +1,10 @@
-"""Starknet Devnet integration helpers"""
-import json
-import requests
+"""Starknet Devnet integration helpers."""
 import logging
 
-from nile.core.account import Account
-from nile.common import get_gateway
+import requests
 
+from nile.common import get_gateway
+from nile.core.account import Account
 
 GATEWAYS = get_gateway()
 
@@ -19,11 +18,11 @@ def get_predeployed_accounts(network):
         # get the account objects from the rest api
         _accounts = response.json()
     except requests.exceptions.MissingSchema:
-        print(f"\n❌ Failed to retrieve gateway from provided network")
+        print("\n❌ Failed to retrieve gateway from provided network")
         return
     except Exception:
-        print(f"\n❌ Error querying the account from the gateway.")
-        print(f"Check you are connected to a starknet-devnet implementation.")
+        print("\n❌ Error querying the account from the gateway.")
+        print("Check you are connected to a starknet-devnet implementation.")
         return
 
     # get the account objects from the rest api
@@ -36,16 +35,16 @@ def get_predeployed_accounts(network):
         logging.info(f"{i}: {_accounts[i]['address']}")
 
         predeployed_info = {
-          "address": int(_accounts[i]['address'], 16),
-          "alias": f"account-{i}",
-          "index": i
+            "address": int(_accounts[i]["address"], 16),
+            "alias": f"account-{i}",
+            "index": i,
         }
 
         _account = _check_and_return_account(
-          _accounts[i]["private_key"],
-          _accounts[i]["public_key"],
-          predeployed_info,
-          network
+            _accounts[i]["private_key"],
+            _accounts[i]["public_key"],
+            predeployed_info,
+            network,
         )
 
         accounts.append(_account)
@@ -56,5 +55,7 @@ def get_predeployed_accounts(network):
 
 def _check_and_return_account(signer, pubkey, predeployed_info, network):
     account = Account(signer, network, predeployed_info)
-    assert int(pubkey, 16) == account.signer.public_key, "Signer pubkey does not match deployed pubkey"
+    assert (
+        int(pubkey, 16) == account.signer.public_key
+    ), "Signer pubkey does not match deployed pubkey"
     return account

--- a/src/nile/devnet.py
+++ b/src/nile/devnet.py
@@ -1,0 +1,60 @@
+"""Starknet Devnet integration helpers"""
+import json
+import requests
+import logging
+
+from nile.core.account import Account
+from nile.common import get_gateway
+
+
+GATEWAYS = get_gateway()
+
+
+def get_predeployed_accounts(network):
+    """Retrieve pre-deployed accounts."""
+    endpoint = f"{GATEWAYS.get(network)}/predeployed_accounts"
+
+    try:
+        response = requests.get(endpoint)
+        # get the account objects from the rest api
+        _accounts = response.json()
+    except requests.exceptions.MissingSchema:
+        print(f"\n❌ Failed to retrieve gateway from provided network")
+        return
+    except Exception:
+        print(f"\n❌ Error querying the account from the gateway.")
+        print(f"Check you are connected to a starknet-devnet implementation.")
+        return
+
+    # get the account objects from the rest api
+    _accounts = response.json()
+
+    # the account instances from core/account
+    accounts = []
+
+    for i in range(len(_accounts)):
+        logging.info(f"{i}: {_accounts[i]['address']}")
+
+        predeployed_info = {
+          "address": int(_accounts[i]['address'], 16),
+          "alias": f"account-{i}",
+          "index": i
+        }
+
+        _account = _check_and_return_account(
+          _accounts[i]["private_key"],
+          _accounts[i]["public_key"],
+          predeployed_info,
+          network
+        )
+
+        accounts.append(_account)
+
+    logging.info("\n🚀 Successfully retrieved pre-deployed accounts")
+    return accounts
+
+
+def _check_and_return_account(signer, pubkey, predeployed_info, network):
+    account = Account(signer, network, predeployed_info)
+    assert int(pubkey, 16) == account.signer.public_key, "Signer pubkey does not match deployed pubkey"
+    return account

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -6,8 +6,8 @@ from nile.core.compile import compile
 from nile.core.declare import declare
 from nile.core.deploy import deploy
 from nile.core.plugins import get_installed_plugins, skip_click_exit
-from nile.utils.get_accounts import get_accounts
 from nile.devnet import get_predeployed_accounts
+from nile.utils.get_accounts import get_accounts
 
 
 class NileRuntimeEnvironment:

--- a/src/nile/nre.py
+++ b/src/nile/nre.py
@@ -7,6 +7,7 @@ from nile.core.declare import declare
 from nile.core.deploy import deploy
 from nile.core.plugins import get_installed_plugins, skip_click_exit
 from nile.utils.get_accounts import get_accounts
+from nile.devnet import get_predeployed_accounts
 
 
 class NileRuntimeEnvironment:
@@ -52,6 +53,9 @@ class NileRuntimeEnvironment:
         """Get or deploy an Account contract."""
         return Account(signer, self.network)
 
-    def get_accounts(self):
+    def get_accounts(self, predeployed=False):
         """Retrieve and manage deployed accounts."""
-        return get_accounts(self.network)
+        if not predeployed:
+            return get_accounts(self.network)
+        else:
+            return get_predeployed_accounts(self.network)


### PR DESCRIPTION
Add `get_predeployed_accounts` method and logic to `cli` and `nre` (compatible with starknet-devnet).