### PR TITLE
Add function to update registered deployment ABI

### DIFF
--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -32,19 +32,29 @@ def update(address, abi, network, alias):
     if not os.path.exists(file):
         raise Exception(f"{file} does not exist")
 
+    if alias is not None:
+        if exists(alias, network):
+            raise Exception(f"Alias {alias} already exists in {file}")
+
     with open(file, "r") as fp:
         lines = fp.readlines()
 
     found = False
     for i in range(len(lines)):
-        line_address = lines[i].strip().split(":")[0]
-        if line_address == address:
+        line = lines[i].strip().split(":")
+        current_address = line[0]
+
+        new_alias = alias
+        if new_alias is None and len(line) > 2:
+            new_alias = line[2]
+
+        if current_address == address:
             found = True
 
             replacement = f"{address}:{abi}"
-            if alias is not None:
-                logging.info(f"📦 Updating deployment as {alias} in {file}")
-                replacement += f":{alias}"
+            if new_alias is not None:
+                logging.info(f"📦 Updating deployment as {new_alias} in {file}")
+                replacement += f":{new_alias}"
             else:
                 logging.info(f"📦 Updating {address} in {file}")
             replacement += "\n"

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -25,16 +25,12 @@ def register(address, abi, network, alias):
         fp.write("\n")
 
 
-def update(address, abi, network, alias):
-    """Update a deployment at an existing address."""
+def update(identifier, abi, network):
+    """Update the ABI for an existing deployment."""
     file = f"{network}.{DEPLOYMENTS_FILENAME}"
 
     if not os.path.exists(file):
         raise Exception(f"{file} does not exist")
-
-    if alias is not None:
-        if exists(alias, network):
-            raise Exception(f"Alias {alias} already exists in {file}")
 
     with open(file, "r") as fp:
         lines = fp.readlines()
@@ -42,27 +38,30 @@ def update(address, abi, network, alias):
     found = False
     for i in range(len(lines)):
         line = lines[i].strip().split(":")
+
         current_address = line[0]
 
-        new_alias = alias
-        if new_alias is None and len(line) > 2:
-            new_alias = line[2]
+        current_alias = None
+        if len(line) > 2:
+            current_alias = line[2]
 
-        if current_address == address:
-            found = True
+        if identifier == current_address or identifier == current_alias:
+            logging.info(f"📦 Updating deployment {identifier} in {file}")
 
-            replacement = f"{address}:{abi}"
-            if new_alias is not None:
-                logging.info(f"📦 Updating deployment as {new_alias} in {file}")
-                replacement += f":{new_alias}"
-            else:
-                logging.info(f"📦 Updating {address} in {file}")
+            replacement = f"{current_address}:{abi}"
+            if current_alias is not None:
+                replacement += f":{current_alias}"
             replacement += "\n"
 
             lines[i] = replacement
 
+            found = True
+            break
+
     if not found:
-        raise Exception(f"Address {address} does not exist in {file}")
+        raise Exception(
+            f"Deployment with address or alias {identifier} does not exist in {file}"
+        )
     else:
         with open(file, "w+") as fp:
             fp.writelines(lines)

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -28,7 +28,7 @@ def register(address, abi, network, alias):
         fp.write("\n")
 
 
-def update(address_or_alias, abi, network):
+def update_abi(address_or_alias, abi, network):
     """
     Update the ABI for an existing deployment that matches an identifier.
 

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -54,7 +54,7 @@ def update(address, abi, network, alias):
     if not found:
         raise Exception(f"Address {address} does not exist in {file}")
     else:
-        with open(file,'w+') as fp:
+        with open(file, "w+") as fp:
             fp.writelines(lines)
 
 

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -28,7 +28,7 @@ def register(address, abi, network, alias):
         fp.write("\n")
 
 
-def update(identifier, abi, network):
+def update(address_or_alias, abi, network):
     """Update the ABI for an existing deployment."""
     file = f"{network}.{DEPLOYMENTS_FILENAME}"
 
@@ -37,6 +37,12 @@ def update(identifier, abi, network):
 
     with open(file, "r") as fp:
         lines = fp.readlines()
+
+    as_address = None
+    try:
+        as_address = normalize_number(address_or_alias)
+    except ValueError:
+        pass
 
     found = False
     for i in range(len(lines)):
@@ -48,8 +54,10 @@ def update(identifier, abi, network):
         if len(line) > 2:
             current_alias = line[2]
 
-        if identifier == current_address or identifier == current_alias:
-            logging.info(f"📦 Updating deployment {identifier} in {file}")
+        if address_or_alias == current_alias or (
+            as_address is not None and as_address == normalize_number(current_address)
+        ):
+            logging.info(f"📦 Updating deployment {address_or_alias} in {file}")
 
             replacement = f"{current_address}:{abi}"
             if current_alias is not None:
@@ -63,7 +71,7 @@ def update(identifier, abi, network):
 
     if not found:
         raise Exception(
-            f"Deployment with address or alias {identifier} does not exist in {file}"
+            f"Deployment with address or alias {address_or_alias} does not exist in {file}"
         )
     else:
         with open(file, "w+") as fp:

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -25,6 +25,39 @@ def register(address, abi, network, alias):
         fp.write("\n")
 
 
+def update(address, abi, network, alias):
+    """Update a deployment at an existing address."""
+    file = f"{network}.{DEPLOYMENTS_FILENAME}"
+
+    if not os.path.exists(file):
+        raise Exception(f"{file} does not exist")
+
+    with open(file, "r") as fp:
+        lines = fp.readlines()
+
+    found = False
+    for i in range(len(lines)):
+        line_address = lines[i].strip().split(":")[0]
+        if line_address == address:
+            found = True
+
+            replacement = f"{address}:{abi}"
+            if alias is not None:
+                logging.info(f"📦 Updating deployment as {alias} in {file}")
+                replacement += f":{alias}"
+            else:
+                logging.info(f"📦 Updating {address} in {file}")
+            replacement += "\n"
+
+            lines[i] = replacement
+
+    if not found:
+        raise Exception(f"Address {address} does not exist in {file}")
+    else:
+        with open(file,'w+') as fp:
+            fp.writelines(lines)
+
+
 def register_class_hash(hash, network, alias):
     """Register a new deployment."""
     file = f"{network}.{DECLARATIONS_FILENAME}"

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -50,12 +50,13 @@ def update_abi(address_or_alias, abi, network):
 
         current_address_hex = line[0]
 
-        current_alias = None
-        if len(line) > 2:
-            current_alias = line[2]
+        current_aliases = None
+        length = len(line)
+        if length > 2:
+            current_aliases = line[-(length - 2) :]
 
         if (
-            type(address_or_alias) is not int and address_or_alias == current_alias
+            type(address_or_alias) is not int and address_or_alias in current_aliases
         ) or (
             type(address_or_alias) is int
             and address_or_alias == normalize_number(current_address_hex)
@@ -63,8 +64,8 @@ def update_abi(address_or_alias, abi, network):
             logging.info(f"📦 Updating deployment {address_or_alias} in {file}")
 
             replacement = f"{current_address_hex}:{abi}"
-            if current_alias is not None:
-                replacement += f":{current_alias}"
+            if current_aliases is not None:
+                replacement += ":" + ":".join(str(x) for x in current_aliases)
             replacement += "\n"
 
             lines[i] = replacement

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -46,30 +46,23 @@ def update_abi(address_or_alias, abi, network):
 
     found = False
     for i in range(len(lines)):
-        line = lines[i].strip().split(":")
+        [address, current_abi, *aliases] = lines[i].strip().split(":")
+        address = normalize_number(address)
+        identifiers = [address]
 
-        current_address_hex = line[0]
+        if type(address_or_alias) is not int:
+            identifiers = aliases
 
-        current_aliases = None
-        length = len(line)
-        if length > 2:
-            current_aliases = line[-(length - 2) :]
-
-        if (
-            type(address_or_alias) is not int and address_or_alias in current_aliases
-        ) or (
-            type(address_or_alias) is int
-            and address_or_alias == normalize_number(current_address_hex)
-        ):
+        if address_or_alias in identifiers:
             logging.info(f"📦 Updating deployment {address_or_alias} in {file}")
 
-            replacement = f"{current_address_hex}:{abi}"
-            if current_aliases is not None:
-                replacement += ":" + ":".join(str(x) for x in current_aliases)
+            # Save address as hex
+            address = hex_address(address)
+            replacement = f"{address}:{abi}"
+            if len(aliases) > 0:
+                replacement += ":" + ":".join(str(x) for x in aliases)
             replacement += "\n"
-
             lines[i] = replacement
-
             found = True
             break
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -39,6 +39,10 @@ def test_update_deployment(update_item, expected_items):
     register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
     register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
 
+    with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
+        lines = fp.readlines()
+    assert len(lines) == 3
+
     update(update_item[0], update_item[1], LOCALHOST)
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
@@ -48,6 +52,12 @@ def test_update_deployment(update_item, expected_items):
     assert_load(expected_items[0])
     assert_load(expected_items[1])
     assert_load(expected_items[2])
+
+    try:
+        update("invalid", CONTRACT_A[1], LOCALHOST)
+        raise AssertionError("update expected to fail due to missing deployment")
+    except Exception as e:
+        assert "does not exist" in str(e)
 
 
 def assert_load(expected_item):
@@ -60,11 +70,3 @@ def assert_load(expected_item):
         address, abi = next(load(alias, LOCALHOST), None)
         assert address == expected_item[0]
         assert abi == expected_item[1]
-
-
-def test_update_deployment_not_exist():
-    try:
-        update("invalid", CONTRACT_A[1], LOCALHOST)
-        raise AssertionError("update expected to fail due to missing deployment")
-    except Exception as e:
-        assert "does not exist" in str(e)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,0 +1,60 @@
+"""Tests for deployments file."""
+from unittest.mock import patch
+
+import pytest
+
+from nile.deployments import register, update, load
+from nile.common import DEPLOYMENTS_FILENAME
+
+LOCALHOST = "localhost"
+
+CONTRACT_A = ("0x01", "artifacts/abis/a.json", None)
+CONTRACT_B = ("0x02", "artifacts/abis/b.json", "contractB")
+CONTRACT_C = ("0x03", "artifacts/abis/c.json", None)
+
+CONTRACT_A2 = ("0x01", "artifacts/abis/a2.json", None)
+CONTRACT_B2 = ("0x02", "artifacts/abis/b2.json", "contractB2")
+CONTRACT_C2 = ("0x03", "artifacts/abis/c2.json", "contractC2")
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "update_item, expected_items",
+    [
+        (CONTRACT_A2, [CONTRACT_A2, CONTRACT_B, CONTRACT_C]),
+        (CONTRACT_B2, [CONTRACT_A, CONTRACT_B2, CONTRACT_C]),
+        (CONTRACT_C2, [CONTRACT_A, CONTRACT_B, CONTRACT_C2]),
+    ],
+)
+def test_update_deployment(update_item, expected_items):
+    register(CONTRACT_A[0], CONTRACT_A[1], LOCALHOST, CONTRACT_A[2]);
+    register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2]);
+    register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2]);
+
+    update(update_item[0], update_item[1], LOCALHOST, update_item[2])
+
+    with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
+        lines = fp.readlines()
+    assert len(lines) == 3
+
+    assert_load(expected_items[0])
+    assert_load(expected_items[1])
+    assert_load(expected_items[2])
+
+
+def assert_load(expected_item):
+    address, abi = next(load(expected_item[0], LOCALHOST), None)
+    assert address == expected_item[0]
+    assert abi == expected_item[1]
+
+    alias = expected_item[2]
+    if alias is not None:
+        address, abi = next(load(alias, LOCALHOST), None)
+        assert address == expected_item[0]
+        assert abi == expected_item[1]
+

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -6,13 +6,18 @@ from nile.deployments import load, register, update
 
 LOCALHOST = "localhost"
 
-CONTRACT_A = ("0x01", "artifacts/abis/a.json", None)
+CONTRACT_A = ("0x01", "artifacts/abis/a.json", "contractA")
 CONTRACT_B = ("0x02", "artifacts/abis/b.json", "contractB")
 CONTRACT_C = ("0x03", "artifacts/abis/c.json", None)
 
-CONTRACT_A2 = ("0x01", "artifacts/abis/a2.json", None)
-CONTRACT_B2 = ("0x02", "artifacts/abis/b2.json", "contractB2")
-CONTRACT_C2 = ("0x03", "artifacts/abis/c2.json", "contractC2")
+CONTRACT_A_UPDATE = ("0x01", "artifacts/abis/a2.json")
+CONTRACT_A_EXPECTED = ("0x01", "artifacts/abis/a2.json", "contractA")
+
+CONTRACT_B_UPDATE = ("contractB", "artifacts/abis/b2.json")
+CONTRACT_B_EXPECTED = ("0x02", "artifacts/abis/b2.json", "contractB")
+
+CONTRACT_C_UPDATE = ("0x03", "artifacts/abis/c2.json")
+CONTRACT_C_EXPECTED = ("0x03", "artifacts/abis/c2.json", None)
 
 
 @pytest.fixture(autouse=True)
@@ -24,9 +29,9 @@ def tmp_working_dir(monkeypatch, tmp_path):
 @pytest.mark.parametrize(
     "update_item, expected_items",
     [
-        (CONTRACT_A2, [CONTRACT_A2, CONTRACT_B, CONTRACT_C]),
-        (CONTRACT_B2, [CONTRACT_A, CONTRACT_B2, CONTRACT_C]),
-        (CONTRACT_C2, [CONTRACT_A, CONTRACT_B, CONTRACT_C2]),
+        (CONTRACT_A_UPDATE, [CONTRACT_A_EXPECTED, CONTRACT_B, CONTRACT_C]),
+        (CONTRACT_B_UPDATE, [CONTRACT_A, CONTRACT_B_EXPECTED, CONTRACT_C]),
+        (CONTRACT_C_UPDATE, [CONTRACT_A, CONTRACT_B, CONTRACT_C_EXPECTED]),
     ],
 )
 def test_update_deployment(update_item, expected_items):
@@ -34,7 +39,7 @@ def test_update_deployment(update_item, expected_items):
     register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
     register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
 
-    update(update_item[0], update_item[1], LOCALHOST, update_item[2])
+    update(update_item[0], update_item[1], LOCALHOST)
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
         lines = fp.readlines()
@@ -55,3 +60,11 @@ def assert_load(expected_item):
         address, abi = next(load(alias, LOCALHOST), None)
         assert address == expected_item[0]
         assert abi == expected_item[1]
+
+
+def test_update_deployment_not_exist():
+    try:
+        update("invalid", CONTRACT_A[1], LOCALHOST)
+        raise AssertionError("update expected to fail due to missing deployment")
+    except Exception as e:
+        assert "does not exist" in str(e)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -11,6 +11,7 @@ A_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000001"
 A_ABI = "artifacts/abis/a.json"
 A_ABI_2 = "artifacts/abis/a2.json"
 A_ALIAS = "contractA"
+A_ALIAS_ALT = "altA"
 
 B_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000002"
 B_ABI = "artifacts/abis/b.json"
@@ -35,7 +36,25 @@ def tmp_working_dir(monkeypatch, tmp_path):
             normalize_number(A_ADDR),
             A_ABI_2,
             [
-                f"{A_ADDR}:{A_ABI_2}:{A_ALIAS}",
+                f"{A_ADDR}:{A_ABI_2}:{A_ALIAS}:{A_ALIAS_ALT}",
+                f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
+                f"{C_ADDR}:{C_ABI}",
+            ],
+        ),
+        (
+            A_ALIAS,
+            A_ABI_2,
+            [
+                f"{A_ADDR}:{A_ABI_2}:{A_ALIAS}:{A_ALIAS_ALT}",
+                f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
+                f"{C_ADDR}:{C_ABI}",
+            ],
+        ),
+        (
+            A_ALIAS_ALT,
+            A_ABI_2,
+            [
+                f"{A_ADDR}:{A_ABI_2}:{A_ALIAS}:{A_ALIAS_ALT}",
                 f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
                 f"{C_ADDR}:{C_ABI}",
             ],
@@ -44,7 +63,7 @@ def tmp_working_dir(monkeypatch, tmp_path):
             B_ALIAS,
             B_ABI_2,
             [
-                f"{A_ADDR}:{A_ABI}:{A_ALIAS}",
+                f"{A_ADDR}:{A_ABI}:{A_ALIAS}:{A_ALIAS_ALT}",
                 f"{B_ADDR}:{B_ABI_2}:{B_ALIAS}",
                 f"{C_ADDR}:{C_ABI}",
             ],
@@ -53,7 +72,7 @@ def tmp_working_dir(monkeypatch, tmp_path):
             normalize_number(C_ADDR),
             C_ABI_2,
             [
-                f"{A_ADDR}:{A_ABI}:{A_ALIAS}",
+                f"{A_ADDR}:{A_ABI}:{A_ALIAS}:{A_ALIAS_ALT}",
                 f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
                 f"{C_ADDR}:{C_ABI_2}",
             ],
@@ -61,7 +80,7 @@ def tmp_working_dir(monkeypatch, tmp_path):
     ],
 )
 def test_update_deployment(address_or_alias, abi, expected_lines):
-    register(normalize_number(A_ADDR), A_ABI, LOCALHOST, A_ALIAS)
+    register(normalize_number(A_ADDR), A_ABI, LOCALHOST, f"{A_ALIAS}:{A_ALIAS_ALT}")
     register(normalize_number(B_ADDR), B_ABI, LOCALHOST, B_ALIAS)
     register(normalize_number(C_ADDR), C_ABI, LOCALHOST, None)
 

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -2,7 +2,7 @@
 import pytest
 
 from nile.common import DEPLOYMENTS_FILENAME
-from nile.deployments import register, update
+from nile.deployments import register, update_abi
 from nile.utils import normalize_number
 
 LOCALHOST = "localhost"
@@ -69,7 +69,7 @@ def test_update_deployment(address_or_alias, abi, expected_lines):
         lines = fp.readlines()
     assert len(lines) == 3
 
-    update(address_or_alias, abi, LOCALHOST)
+    update_abi(address_or_alias, abi, LOCALHOST)
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
         lines = fp.readlines()
@@ -82,7 +82,7 @@ def test_update_deployment(address_or_alias, abi, expected_lines):
 
 def test_update_non_existent_identifier():
     try:
-        update("invalid", A_ABI, LOCALHOST)
+        update_abi("invalid", A_ABI, LOCALHOST)
         raise AssertionError("update expected to fail due to missing deployment")
     except Exception as e:
         assert "does not exist" in str(e)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -7,44 +7,19 @@ from nile.utils import normalize_number
 
 LOCALHOST = "localhost"
 
-CONTRACT_A = (
-    "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "artifacts/abis/a.json",
-    "contractA",
-)
-CONTRACT_B = (
-    "0x0000000000000000000000000000000000000000000000000000000000000002",
-    "artifacts/abis/b.json",
-    "contractB",
-)
-CONTRACT_C = (
-    "0x0000000000000000000000000000000000000000000000000000000000000003",
-    "artifacts/abis/c.json",
-    None,
-)
+A_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000001"
+A_ABI = "artifacts/abis/a.json"
+A_ABI_2 = "artifacts/abis/a2.json"
+A_ALIAS = "contractA"
 
-CONTRACT_A_UPDATE = (
-    "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "artifacts/abis/a2.json",
-)
-CONTRACT_A_EXPECTED = (
-    "0x0000000000000000000000000000000000000000000000000000000000000001",
-    "artifacts/abis/a2.json",
-    "contractA",
-)
+B_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000002"
+B_ABI = "artifacts/abis/b.json"
+B_ABI_2 = "artifacts/abis/b2.json"
+B_ALIAS = "contractB"
 
-CONTRACT_B_UPDATE = ("contractB", "artifacts/abis/b2.json")
-CONTRACT_B_EXPECTED = (
-    "0x0000000000000000000000000000000000000000000000000000000000000002",
-    "artifacts/abis/b2.json",
-    "contractB",
-)
-
-CONTRACT_C_UPDATE = (
-    "0x0000000000000000000000000000000000000000000000000000000000000003",
-    "artifacts/abis/c2.json",
-)
-CONTRACT_C_EXPECTED = CONTRACT_C_UPDATE
+C_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000003"
+C_ABI = "artifacts/abis/c.json"
+C_ABI_2 = "artifacts/abis/c2.json"
 
 
 @pytest.fixture(autouse=True)
@@ -54,40 +29,58 @@ def tmp_working_dir(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "update_item, expected_items",
+    "address_or_alias, abi, expected_lines",
     [
-        (CONTRACT_A_UPDATE, [CONTRACT_A_EXPECTED, CONTRACT_B, CONTRACT_C]),
-        (CONTRACT_B_UPDATE, [CONTRACT_A, CONTRACT_B_EXPECTED, CONTRACT_C]),
-        (CONTRACT_C_UPDATE, [CONTRACT_A, CONTRACT_B, CONTRACT_C_EXPECTED]),
+        (
+            normalize_number(A_ADDR),
+            A_ABI_2,
+            [
+                f"{A_ADDR}:{A_ABI_2}:{A_ALIAS}",
+                f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
+                f"{C_ADDR}:{C_ABI}",
+            ],
+        ),
+        (
+            B_ALIAS,
+            B_ABI_2,
+            [
+                f"{A_ADDR}:{A_ABI}:{A_ALIAS}",
+                f"{B_ADDR}:{B_ABI_2}:{B_ALIAS}",
+                f"{C_ADDR}:{C_ABI}",
+            ],
+        ),
+        (
+            normalize_number(C_ADDR),
+            C_ABI_2,
+            [
+                f"{A_ADDR}:{A_ABI}:{A_ALIAS}",
+                f"{B_ADDR}:{B_ABI}:{B_ALIAS}",
+                f"{C_ADDR}:{C_ABI_2}",
+            ],
+        ),
     ],
 )
-def test_update_deployment(update_item, expected_items):
-    register(normalize_number(CONTRACT_A[0]), CONTRACT_A[1], LOCALHOST, CONTRACT_A[2])
-    register(normalize_number(CONTRACT_B[0]), CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
-    register(normalize_number(CONTRACT_C[0]), CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
+def test_update_deployment(address_or_alias, abi, expected_lines):
+    register(normalize_number(A_ADDR), A_ABI, LOCALHOST, A_ALIAS)
+    register(normalize_number(B_ADDR), B_ABI, LOCALHOST, B_ALIAS)
+    register(normalize_number(C_ADDR), C_ABI, LOCALHOST, None)
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
         lines = fp.readlines()
     assert len(lines) == 3
 
-    update(update_item[0], update_item[1], LOCALHOST)
+    update(address_or_alias, abi, LOCALHOST)
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
         lines = fp.readlines()
     assert len(lines) == 3
 
-    assert (
-        lines[0].strip()
-        == f"{expected_items[0][0]}:{expected_items[0][1]}:{expected_items[0][2]}"
-    )
-    assert (
-        lines[1].strip()
-        == f"{expected_items[1][0]}:{expected_items[1][1]}:{expected_items[1][2]}"
-    )
-    assert lines[2].strip() == f"{expected_items[2][0]}:{expected_items[2][1]}"
+    assert lines[0].strip() == expected_lines[0]
+    assert lines[1].strip() == expected_lines[1]
+    assert lines[2].strip() == expected_lines[2]
 
     try:
-        update("invalid", CONTRACT_A[1], LOCALHOST)
+        update("invalid", A_ABI, LOCALHOST)
         raise AssertionError("update expected to fail due to missing deployment")
     except Exception as e:
         assert "does not exist" in str(e)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -1,10 +1,8 @@
 """Tests for deployments file."""
-from unittest.mock import patch
-
 import pytest
 
-from nile.deployments import register, update, load
 from nile.common import DEPLOYMENTS_FILENAME
+from nile.deployments import load, register, update
 
 LOCALHOST = "localhost"
 
@@ -32,9 +30,9 @@ def tmp_working_dir(monkeypatch, tmp_path):
     ],
 )
 def test_update_deployment(update_item, expected_items):
-    register(CONTRACT_A[0], CONTRACT_A[1], LOCALHOST, CONTRACT_A[2]);
-    register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2]);
-    register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2]);
+    register(CONTRACT_A[0], CONTRACT_A[1], LOCALHOST, CONTRACT_A[2])
+    register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
+    register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
 
     update(update_item[0], update_item[1], LOCALHOST, update_item[2])
 
@@ -57,4 +55,3 @@ def assert_load(expected_item):
         address, abi = next(load(alias, LOCALHOST), None)
         assert address == expected_item[0]
         assert abi == expected_item[1]
-

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -6,18 +6,48 @@ from nile.deployments import register, update
 
 LOCALHOST = "localhost"
 
-CONTRACT_A = ("0x01", "artifacts/abis/a.json", "contractA")
-CONTRACT_B = ("0x02", "artifacts/abis/b.json", "contractB")
-CONTRACT_C = ("0x03", "artifacts/abis/c.json", None)
+CONTRACT_A = (
+    "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "artifacts/abis/a.json",
+    "contractA",
+)
+CONTRACT_B = (
+    "0x0000000000000000000000000000000000000000000000000000000000000002",
+    "artifacts/abis/b.json",
+    "contractB",
+)
+CONTRACT_C = (
+    "0x0000000000000000000000000000000000000000000000000000000000000003",
+    "artifacts/abis/c.json",
+    None,
+)
 
-CONTRACT_A_UPDATE = ("0x01", "artifacts/abis/a2.json")
-CONTRACT_A_EXPECTED = ("0x01", "artifacts/abis/a2.json", "contractA")
+CONTRACT_A_UPDATE = (
+    "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "artifacts/abis/a2.json",
+)
+CONTRACT_A_EXPECTED = (
+    "0x0000000000000000000000000000000000000000000000000000000000000001",
+    "artifacts/abis/a2.json",
+    "contractA",
+)
 
 CONTRACT_B_UPDATE = ("contractB", "artifacts/abis/b2.json")
-CONTRACT_B_EXPECTED = ("0x02", "artifacts/abis/b2.json", "contractB")
+CONTRACT_B_EXPECTED = (
+    "0x0000000000000000000000000000000000000000000000000000000000000002",
+    "artifacts/abis/b2.json",
+    "contractB",
+)
 
-CONTRACT_C_UPDATE = ("0x03", "artifacts/abis/c2.json")
-CONTRACT_C_EXPECTED = ("0x03", "artifacts/abis/c2.json", None)
+CONTRACT_C_UPDATE = (
+    "0x0000000000000000000000000000000000000000000000000000000000000003",
+    "artifacts/abis/c2.json",
+)
+CONTRACT_C_EXPECTED = (
+    "0x0000000000000000000000000000000000000000000000000000000000000003",
+    "artifacts/abis/c2.json",
+    None,
+)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -79,6 +79,8 @@ def test_update_deployment(address_or_alias, abi, expected_lines):
     assert lines[1].strip() == expected_lines[1]
     assert lines[2].strip() == expected_lines[2]
 
+
+def test_update_non_existent_identifier():
     try:
         update("invalid", A_ABI, LOCALHOST)
         raise AssertionError("update expected to fail due to missing deployment")

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -2,7 +2,7 @@
 import pytest
 
 from nile.common import DEPLOYMENTS_FILENAME
-from nile.deployments import load, register, update
+from nile.deployments import register, update
 
 LOCALHOST = "localhost"
 
@@ -49,24 +49,18 @@ def test_update_deployment(update_item, expected_items):
         lines = fp.readlines()
     assert len(lines) == 3
 
-    assert_load(expected_items[0])
-    assert_load(expected_items[1])
-    assert_load(expected_items[2])
+    assert (
+        lines[0].strip()
+        == f"{expected_items[0][0]}:{expected_items[0][1]}:{expected_items[0][2]}"
+    )
+    assert (
+        lines[1].strip()
+        == f"{expected_items[1][0]}:{expected_items[1][1]}:{expected_items[1][2]}"
+    )
+    assert lines[2].strip() == f"{expected_items[2][0]}:{expected_items[2][1]}"
 
     try:
         update("invalid", CONTRACT_A[1], LOCALHOST)
         raise AssertionError("update expected to fail due to missing deployment")
     except Exception as e:
         assert "does not exist" in str(e)
-
-
-def assert_load(expected_item):
-    address, abi = next(load(expected_item[0], LOCALHOST), None)
-    assert address == expected_item[0]
-    assert abi == expected_item[1]
-
-    alias = expected_item[2]
-    if alias is not None:
-        address, abi = next(load(alias, LOCALHOST), None)
-        assert address == expected_item[0]
-        assert abi == expected_item[1]

--- a/tests/test_deployments.py
+++ b/tests/test_deployments.py
@@ -3,6 +3,7 @@ import pytest
 
 from nile.common import DEPLOYMENTS_FILENAME
 from nile.deployments import register, update
+from nile.utils import normalize_number
 
 LOCALHOST = "localhost"
 
@@ -43,11 +44,7 @@ CONTRACT_C_UPDATE = (
     "0x0000000000000000000000000000000000000000000000000000000000000003",
     "artifacts/abis/c2.json",
 )
-CONTRACT_C_EXPECTED = (
-    "0x0000000000000000000000000000000000000000000000000000000000000003",
-    "artifacts/abis/c2.json",
-    None,
-)
+CONTRACT_C_EXPECTED = CONTRACT_C_UPDATE
 
 
 @pytest.fixture(autouse=True)
@@ -65,9 +62,9 @@ def tmp_working_dir(monkeypatch, tmp_path):
     ],
 )
 def test_update_deployment(update_item, expected_items):
-    register(CONTRACT_A[0], CONTRACT_A[1], LOCALHOST, CONTRACT_A[2])
-    register(CONTRACT_B[0], CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
-    register(CONTRACT_C[0], CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
+    register(normalize_number(CONTRACT_A[0]), CONTRACT_A[1], LOCALHOST, CONTRACT_A[2])
+    register(normalize_number(CONTRACT_B[0]), CONTRACT_B[1], LOCALHOST, CONTRACT_B[2])
+    register(normalize_number(CONTRACT_C[0]), CONTRACT_C[1], LOCALHOST, CONTRACT_C[2])
 
     with open(f"{LOCALHOST}.{DEPLOYMENTS_FILENAME}", "r") as fp:
         lines = fp.readlines()


### PR DESCRIPTION
Fixes #204

The `update_abi` function takes an identifier (address or alias) as input, and updates the ABI while keeping the same address and alias.