### PR TITLE
Change `register_class_hash` to take int

### DIFF
--- a/src/nile/core/declare.py
+++ b/src/nile/core/declare.py
@@ -44,7 +44,7 @@ def declare(
     logging.info(f"⏳ Successfully sent declaration of {contract_name} as {padded_hash}")
     logging.info(f"🧾 Transaction hash: {hex(tx_hash)}")
 
-    deployments.register_class_hash(padded_hash, network, alias)
+    deployments.register_class_hash(class_hash, network, alias)
 
     if watch_mode is not None:
         if status(tx_hash, network, watch_mode).status.is_rejected:

--- a/src/nile/deployments.py
+++ b/src/nile/deployments.py
@@ -104,16 +104,20 @@ def register_class_hash(hash, network, alias):
     """Register a new deployment."""
     file = f"{network}.{DECLARATIONS_FILENAME}"
 
+    padded_hash = hex_class_hash(hash)
+
     if class_hash_exists(hash, network):
-        raise Exception(f"Hash {hash[:6]}...{hash[-6:]} already exists in {file}")
+        raise Exception(
+            f"Hash {padded_hash[:6]}...{padded_hash[-6:]} already exists in {file}"
+        )
 
     with open(file, "a") as fp:
         if alias is not None:
             logging.info(f"📦 Registering {alias} in {file}")
         else:
-            logging.info(f"📦 Registering {hash} in {file}")
+            logging.info(f"📦 Registering {padded_hash} in {file}")
 
-        fp.write(f"{hash}")
+        fp.write(f"{padded_hash}")
         if alias is not None:
             fp.write(f":{alias}")
         fp.write("\n")

--- a/tests/commands/test_declare.py
+++ b/tests/commands/test_declare.py
@@ -51,7 +51,7 @@ def test_alias_exists():
                 "max_fee": "0",
                 "mainnet_token": None,
             },
-            [hex_class_hash(HASH), NETWORK, None],  # expected register
+            [HASH, NETWORK, None],  # expected register
         ),
         (
             [SENDER, CONTRACT, SIGNATURE, NETWORK, ALIAS],  # args
@@ -64,7 +64,7 @@ def test_alias_exists():
                 "max_fee": "0",
                 "mainnet_token": None,
             },
-            [hex_class_hash(HASH), NETWORK, ALIAS],  # expected register
+            [HASH, NETWORK, ALIAS],  # expected register
         ),
         (
             [SENDER, CONTRACT, SIGNATURE, NETWORK, ALIAS, PATH],  # args
@@ -77,7 +77,7 @@ def test_alias_exists():
                 "max_fee": "0",
                 "mainnet_token": None,
             },
-            [hex_class_hash(HASH), NETWORK, ALIAS],  # expected register
+            [HASH, NETWORK, ALIAS],  # expected register
         ),
         (
             [SENDER, CONTRACT, SIGNATURE, NETWORK, ALIAS, PATH, MAX_FEE],  # args
@@ -90,7 +90,7 @@ def test_alias_exists():
                 "max_fee": str(MAX_FEE),
                 "mainnet_token": None,
             },
-            [hex_class_hash(HASH), NETWORK, ALIAS],  # expected register
+            [HASH, NETWORK, ALIAS],  # expected register
         ),
     ],
 )


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/nile/issues/287

According to [hex/int pattern](https://github.com/OpenZeppelin/nile/blob/main/CONTRIBUTING.md#hexint-pattern), internal API must use only hex.

I assume https://github.com/OpenZeppelin/nile/blob/main/src/nile/deployments.py is considered internal API (since it is only intended for use by Nile and plugins).

So functions relating to class hashes in the deployment files should take `int` but write to log and files as hex strings.