### PR TITLE
Fix account invariant

### DIFF
--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -96,7 +96,7 @@ class Account(AsyncObject):
             )
             if output is not None:
                 address, index = output
-                self.address = address
+                self.address = normalize_number(address)
                 self.index = index
 
         # we should replace this with static type checks

--- a/src/nile/starknet_cli.py
+++ b/src/nile/starknet_cli.py
@@ -94,7 +94,7 @@ def set_command_args(**kwargs):
 
     if kwargs.get("max_fee"):
         command_args.append("--max_fee")
-        command_args.extend(prepare_params(kwargs.get("max_fee")))
+        command_args.append(str(kwargs.get("max_fee")))
 
     if kwargs.get("method"):
         command_args.append("--function")

--- a/tests/test_starknet_cli.py
+++ b/tests/test_starknet_cli.py
@@ -71,8 +71,8 @@ def test__add_args(args, expected):
     "args, expected",
     [
         (
-            {"address": ADDRESS, "inputs": INPUTS},
-            ["--address", ADDRESS, "--inputs", "1", "2"],
+            {"address": ADDRESS, "inputs": INPUTS, "max_fee": "324652"},
+            ["--address", ADDRESS, "--inputs", "1", "2", "--max_fee", "324652"],
         ),
         (
             {"inputs": INPUTS, "contract_name": CONTRACT_NAME},


### PR DESCRIPTION
Fixes https://github.com/OpenZeppelin/nile/issues/301. This PR also fixes `max_fee`, which was being passed to `starknet_cli` as an array instead of a number:

`['1', '2', '3', '4']` instead of `1234`