### PR TITLE
Fix network handling

### DIFF
--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -29,6 +29,7 @@ UNIVERSAL_DEPLOYER_ADDRESS = (
     "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
 )
 DEFAULT_GATEWAYS = {
+    "localhost": "http://127.0.0.1:5050/",
     "goerli2": "https://alpha4-2.starknet.io",
     "integration": "https://external.integration.starknet.io",
 }
@@ -36,23 +37,27 @@ DEFAULT_GATEWAYS = {
 
 def get_gateways():
     """Get the StarkNet node details."""
-    try:
+    if os.path.exists(NODE_FILENAME):
         with open(NODE_FILENAME, "r") as f:
             gateway = json.load(f)
-            gateways = {**gateway, **DEFAULT_GATEWAYS}
+            gateways = {**DEFAULT_GATEWAYS, **gateway}
             return gateways
-    except FileNotFoundError:
-        gateway = create_node_json()
-        gateways = {**gateway, **DEFAULT_GATEWAYS}
-        return gateways
+    else:
+        return DEFAULT_GATEWAYS
 
 
-def create_node_json(network="localhost", gateway_url="http://127.0.0.1:5050/"):
-    """Create node.json and return gateways."""
-    with open(NODE_FILENAME, "w") as f:
-        gateway = {network: gateway_url}
-        f.write(json.dumps(gateway))
-        return gateway
+def create_node_json(network, gateway_url):
+    """Create or update node.json with custom network."""
+    if not os.path.exists(NODE_FILENAME):
+        with open(NODE_FILENAME, "w") as fp:
+            json.dump({network: gateway_url}, fp)
+    else:
+        with open(NODE_FILENAME, "r") as fp:
+            gateways = json.load(fp)
+            gateways[network] = gateway_url
+
+        with open(NODE_FILENAME, "w") as fp:
+            json.dump(gateways, fp, indent=2)
 
 
 GATEWAYS = get_gateways()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -28,7 +28,7 @@ UNIVERSAL_DEPLOYER_ADDRESS = (
     # subject to change
     "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
 )
-OTHER_NETWORKS = {
+DEFAULT_GATEWAYS = {
     "goerli2": "https://alpha4-2.starknet.io",
     "integration": "https://external.integration.starknet.io",
 }
@@ -43,10 +43,10 @@ def get_gateways():
 
     except FileNotFoundError:
         with open(NODE_FILENAME, "w") as f:
-            networks = {"localhost": "http://127.0.0.1:5050/", **OTHER_NETWORKS}
-            f.write(json.dumps(networks, indent=2))
+            gateways = {"localhost": "http://127.0.0.1:5050/", **DEFAULT_GATEWAYS}
+            f.write(json.dumps(gateways, indent=2))
 
-            return networks
+            return gateways
 
 
 GATEWAYS = get_gateways()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -38,20 +38,21 @@ def get_gateways():
     """Get the StarkNet node details."""
     try:
         with open(NODE_FILENAME, "r") as f:
-            gateways = json.load(f)
+            gateway = json.load(f)
+            gateways = {**gateway, **DEFAULT_GATEWAYS}
             return gateways
-
     except FileNotFoundError:
-        gateways = create_node_json()
+        gateway = create_node_json()
+        gateways = {**gateway, **DEFAULT_GATEWAYS}
         return gateways
 
 
 def create_node_json(network="localhost", gateway_url="http://127.0.0.1:5050/"):
     """Create node.json and return gateways."""
     with open(NODE_FILENAME, "w") as f:
-        gateways = {network: gateway_url, **DEFAULT_GATEWAYS}
-        f.write(json.dumps(gateways, indent=2))
-        return gateways
+        gateway = {network: gateway_url}
+        f.write(json.dumps(gateway))
+        return gateway
 
 
 GATEWAYS = get_gateways()

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -28,6 +28,10 @@ UNIVERSAL_DEPLOYER_ADDRESS = (
     # subject to change
     "0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf"
 )
+OTHER_NETWORKS = {
+    "goerli2": "https://alpha4-2.starknet.io",
+    "integration": "https://external.integration.starknet.io",
+}
 
 
 def get_gateways():
@@ -39,11 +43,7 @@ def get_gateways():
 
     except FileNotFoundError:
         with open(NODE_FILENAME, "w") as f:
-            networks = {
-                "localhost": "http://127.0.0.1:5050/",
-                "goerli2": "https://alpha4-2.starknet.io",
-                "integration": "https://external.integration.starknet.io",
-            }
+            networks = {"localhost": "http://127.0.0.1:5050/", **OTHER_NETWORKS}
             f.write(json.dumps(networks, indent=2))
 
             return networks

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -39,8 +39,8 @@ def get_gateways():
     """Get the StarkNet node details."""
     if os.path.exists(NODE_FILENAME):
         with open(NODE_FILENAME, "r") as f:
-            gateway = json.load(f)
-            gateways = {**DEFAULT_GATEWAYS, **gateway}
+            custom_gateways = json.load(f)
+            gateways = {**DEFAULT_GATEWAYS, **custom_gateways}
             return gateways
     else:
         return DEFAULT_GATEWAYS

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -46,7 +46,7 @@ def get_gateways():
         return DEFAULT_GATEWAYS
 
 
-def create_node_json(network, gateway_url):
+def write_node_json(network, gateway_url):
     """Create or update node.json with custom network."""
     if not os.path.exists(NODE_FILENAME):
         with open(NODE_FILENAME, "w") as fp:

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -52,11 +52,10 @@ def write_node_json(network, gateway_url):
         with open(NODE_FILENAME, "w") as fp:
             json.dump({network: gateway_url}, fp)
     else:
-        with open(NODE_FILENAME, "r") as fp:
+        with open(NODE_FILENAME, "r+") as fp:
             gateways = json.load(fp)
             gateways[network] = gateway_url
-
-        with open(NODE_FILENAME, "w") as fp:
+            fp.seek(0)
             json.dump(gateways, fp, indent=2)
 
 

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -38,15 +38,20 @@ def get_gateways():
     """Get the StarkNet node details."""
     try:
         with open(NODE_FILENAME, "r") as f:
-            gateway = json.load(f)
-            return gateway
+            gateways = json.load(f)
+            return gateways
 
     except FileNotFoundError:
-        with open(NODE_FILENAME, "w") as f:
-            gateways = {"localhost": "http://127.0.0.1:5050/", **DEFAULT_GATEWAYS}
-            f.write(json.dumps(gateways, indent=2))
+        gateways = create_node_json()
+        return gateways
 
-            return gateways
+
+def create_node_json(network="localhost", gateway_url="http://127.0.0.1:5050/"):
+    """Create node.json and return gateways."""
+    with open(NODE_FILENAME, "w") as f:
+        gateways = {network: gateway_url, **DEFAULT_GATEWAYS}
+        f.write(json.dumps(gateways, indent=2))
+        return gateways
 
 
 GATEWAYS = get_gateways()

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -2,7 +2,7 @@
 import logging
 import subprocess
 
-from nile.common import DEFAULT_GATEWAYS, create_node_json
+from nile.common import DEFAULT_GATEWAYS, write_node_json
 
 
 def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
@@ -15,7 +15,7 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
             network = host
         gateway_url = f"http://{host}:{port}/"
         if DEFAULT_GATEWAYS.get(network) != gateway_url:
-            create_node_json(network, gateway_url)
+            write_node_json(network, gateway_url)
 
         command = ["starknet-devnet", "--host", host, "--port", str(port)]
 

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -3,7 +3,7 @@ import json
 import logging
 import subprocess
 
-from nile.common import NODE_FILENAME, OTHER_NETWORKS
+from nile.common import NODE_FILENAME, DEFAULT_GATEWAYS
 
 
 def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
@@ -16,7 +16,7 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
         else:
             network = host
         gateway_url = f"http://{host}:{port}/"
-        gateways = {network: gateway_url, **OTHER_NETWORKS}
+        gateways = {network: gateway_url, **DEFAULT_GATEWAYS}
 
         with open(file, "w+") as f:
             json.dump(gateways, f, indent=2)

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -2,7 +2,7 @@
 import logging
 import subprocess
 
-from nile.common import create_node_json
+from nile.common import DEFAULT_GATEWAYS, create_node_json
 
 
 def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
@@ -14,7 +14,8 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
         else:
             network = host
         gateway_url = f"http://{host}:{port}/"
-        create_node_json(network, gateway_url)
+        if DEFAULT_GATEWAYS.get(network) != gateway_url:
+            create_node_json(network, gateway_url)
 
         command = ["starknet-devnet", "--host", host, "--port", str(port)]
 

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -3,7 +3,7 @@ import json
 import logging
 import subprocess
 
-from nile.common import NODE_FILENAME
+from nile.common import NODE_FILENAME, OTHER_NETWORKS
 
 
 def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
@@ -16,10 +16,10 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
         else:
             network = host
         gateway_url = f"http://{host}:{port}/"
-        gateway = {network: gateway_url}
+        gateways = {network: gateway_url, **OTHER_NETWORKS}
 
         with open(file, "w+") as f:
-            json.dump(gateway, f)
+            json.dump(gateways, f, indent=2)
 
         command = ["starknet-devnet", "--host", host, "--port", str(port)]
 

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -1,25 +1,20 @@
 """Command to start StarkNet local network."""
-import json
 import logging
 import subprocess
 
-from nile.common import NODE_FILENAME, DEFAULT_GATEWAYS
+from nile.common import create_node_json
 
 
 def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands
-        file = NODE_FILENAME
         if host == "127.0.0.1":
             network = "localhost"
         else:
             network = host
         gateway_url = f"http://{host}:{port}/"
-        gateways = {network: gateway_url, **DEFAULT_GATEWAYS}
-
-        with open(file, "w+") as f:
-            json.dump(gateways, f, indent=2)
+        create_node_json(network, gateway_url)
 
         command = ["starknet-devnet", "--host", host, "--port", str(port)]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,7 +146,7 @@ async def test_node_forwards_args(mock_subprocess):
     reason="Issue in cairo-lang. "
     "See https://github.com/starkware-libs/cairo-lang/issues/27",
 )
-async def test_node_runs_gateway(opts, expected, capfd):
+async def test_node_runs_gateway(opts, expected):
     # Node life
     seconds = 20
 
@@ -175,10 +175,6 @@ async def test_node_runs_gateway(opts, expected, capfd):
     status = check_node(p, seconds, gateway_url)
     p.join()
     assert status == 200
-
-    # Check that node displays correct gateway_url
-    out, _ = capfd.readouterr()
-    assert f"Listening on {expected}" in out
 
     # Assert network and gateway_url is correct in node.json file
     if expected != "http://127.0.0.1:5050/":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,9 +146,9 @@ async def test_node_forwards_args(mock_subprocess):
     reason="Issue in cairo-lang. "
     "See https://github.com/starkware-libs/cairo-lang/issues/27",
 )
-async def test_node_runs_gateway(opts, expected):
+async def test_node_runs_gateway(opts, expected, capfd):
     # Node life
-    seconds = 15
+    seconds = 20
 
     host = opts.get("--host", "127.0.0.1")
     port = opts.get("--port", "5050")
@@ -176,11 +176,16 @@ async def test_node_runs_gateway(opts, expected):
     p.join()
     assert status == 200
 
+    # Check that node displays correct gateway_url
+    out, _ = capfd.readouterr()
+    assert f"Listening on {expected}" in out
+
     # Assert network and gateway_url is correct in node.json file
-    file = NODE_FILENAME
-    with open(file, "r") as f:
-        gateway = json.load(f)
-    assert gateway.get(network) == expected
+    if expected != "http://127.0.0.1:5050/":
+        file = NODE_FILENAME
+        with open(file, "r") as f:
+            gateway = json.load(f)
+        assert gateway.get(network) == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,8 +1,13 @@
 """Tests for common library."""
+import json
+from unittest.mock import mock_open, patch
+
 import pytest
 
 from nile.common import (
     DEFAULT_GATEWAYS,
+    NODE_FILENAME,
+    create_node_json,
     get_gateways,
     parse_information,
     prepare_params,
@@ -16,6 +21,7 @@ LIST2 = [1, 2, 3, [4, 5, 6]]
 LIST3 = [1, 2, 3, [4, 5, 6, [7, 8, 9]]]
 STDOUT_1 = "SDTOUT_1"
 STDOUT_2 = "SDTOUT_2"
+LOCAL_GATEWAY = {"localhost": "http://127.0.0.1:5050/"}
 
 
 @pytest.mark.parametrize(
@@ -58,6 +64,23 @@ def test_parse_information():
 
 def test_get_gateways():
     gateways = get_gateways()
-    expected = {"localhost": "http://127.0.0.1:5050/", **DEFAULT_GATEWAYS}
+    expected = {**LOCAL_GATEWAY, **DEFAULT_GATEWAYS}
 
     assert gateways == expected
+
+
+@pytest.mark.parametrize(
+    "args, gateway", [(None, LOCAL_GATEWAY), (["a", "b"], {"a": "b"})]
+)
+def test_create_node_json(args, gateway):
+    open_mock = mock_open()
+    with patch("nile.common.open", open_mock, create=True):
+        if args is None:
+            create_node_json()
+        else:
+            create_node_json(*args)
+
+    expected = json.dumps({**gateway, **DEFAULT_GATEWAYS}, indent=2)
+
+    open_mock.assert_called_with(NODE_FILENAME, "w")
+    open_mock.return_value.write.assert_called_once_with(expected)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -18,12 +18,6 @@ STDOUT_1 = "SDTOUT_1"
 STDOUT_2 = "SDTOUT_2"
 
 
-@pytest.fixture(autouse=True)
-def tmp_working_dir(monkeypatch, tmp_path):
-    monkeypatch.chdir(tmp_path)
-    return tmp_path
-
-
 @pytest.mark.parametrize(
     "args, expected",
     [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -68,7 +68,9 @@ def test_get_gateways():
     assert gateways == expected
 
     # Check create_node_json is called with FileNotFoundError
-    with patch("nile.common.create_node_json", return_value=LOCAL_GATEWAY) as mock_create:
+    with patch(
+        "nile.common.create_node_json", return_value=LOCAL_GATEWAY
+    ) as mock_create:
         open_mock = mock_open()
         with patch("nile.common.open", open_mock):
             open_mock.side_effect = FileNotFoundError

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -65,8 +65,17 @@ def test_parse_information():
 def test_get_gateways():
     gateways = get_gateways()
     expected = {**LOCAL_GATEWAY, **DEFAULT_GATEWAYS}
-
     assert gateways == expected
+
+    # Check create_node_json is called with FileNotFoundError
+    with patch("nile.common.create_node_json", return_value=LOCAL_GATEWAY) as mock_create:
+        open_mock = mock_open()
+        with patch("nile.common.open", open_mock):
+            open_mock.side_effect = FileNotFoundError
+            gateways = get_gateways()
+
+            mock_create.assert_called_once()
+            assert gateways == expected
 
 
 @pytest.mark.parametrize(
@@ -80,7 +89,7 @@ def test_create_node_json(args, gateway):
         else:
             create_node_json(*args)
 
-    expected = json.dumps({**gateway, **DEFAULT_GATEWAYS}, indent=2)
+    expected = json.dumps({**gateway})
 
     open_mock.assert_called_with(NODE_FILENAME, "w")
     open_mock.return_value.write.assert_called_once_with(expected)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,7 +1,13 @@
 """Tests for common library."""
 import pytest
 
-from nile.common import parse_information, prepare_params, stringify
+from nile.common import (
+    OTHER_NETWORKS,
+    get_gateways,
+    parse_information,
+    prepare_params,
+    stringify,
+)
 
 NETWORK = "goerli"
 ARGS = ["1", "2", "3"]
@@ -10,6 +16,12 @@ LIST2 = [1, 2, 3, [4, 5, 6]]
 LIST3 = [1, 2, 3, [4, 5, 6, [7, 8, 9]]]
 STDOUT_1 = "SDTOUT_1"
 STDOUT_2 = "SDTOUT_2"
+
+
+@pytest.fixture(autouse=True)
+def tmp_working_dir(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
 
 
 @pytest.mark.parametrize(
@@ -48,3 +60,10 @@ def test_parse_information():
 
     _a, _b = parse_information(target)
     assert _a, _b == (a, b)
+
+
+def test_get_gateways():
+    gateways = get_gateways()
+    expected = {"localhost": "http://127.0.0.1:5050/", **OTHER_NETWORKS}
+
+    assert gateways == expected

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -2,7 +2,7 @@
 import pytest
 
 from nile.common import (
-    OTHER_NETWORKS,
+    DEFAULT_GATEWAYS,
     get_gateways,
     parse_information,
     prepare_params,
@@ -58,6 +58,6 @@ def test_parse_information():
 
 def test_get_gateways():
     gateways = get_gateways()
-    expected = {"localhost": "http://127.0.0.1:5050/", **OTHER_NETWORKS}
+    expected = {"localhost": "http://127.0.0.1:5050/", **DEFAULT_GATEWAYS}
 
     assert gateways == expected

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,7 +6,7 @@ import pytest
 from nile.common import (
     DEFAULT_GATEWAYS,
     NODE_FILENAME,
-    create_node_json,
+    write_node_json,
     get_gateways,
     parse_information,
     prepare_params,
@@ -76,7 +76,7 @@ def test_parse_information():
 )
 def test_get_gateways(network, url, gateway):
     if network is not None:
-        create_node_json(network, url)
+        write_node_json(network, url)
 
     gateways = get_gateways()
     expected = {**DEFAULT_GATEWAYS, **gateway}
@@ -98,10 +98,10 @@ def test_get_gateways(network, url, gateway):
         ),
     ],
 )
-def test_create_node_json(args1, args2, gateways):
+def test_write_node_json(args1, args2, gateways):
     # Check that node.json is created and adds keys
-    create_node_json(*args1)
-    create_node_json(*args2)
+    write_node_json(*args1)
+    write_node_json(*args2)
 
     with open(NODE_FILENAME, "r") as fp:
         result = fp.read()


### PR DESCRIPTION
Resolves #297.

The current flow of network handling creates the awkward issue of an unresolved query in perpetuity when the node.json exists but the network key does not. This PR, therefore, proposes to add `goerli2` and `integration` gateways to the node.json in the `nile node` command. This means that the `goerli2` and `integration` gateways will be accessible irrespective of the node.json file's existence.