### PR TITLE
Add `nile-account` flag to set Nile artifacts path

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -159,6 +159,7 @@ async def deploy(
 @click.option("--max_fee", nargs=1)
 @click.option("--alias")
 @click.option("--overriding_path")
+@click.option("--nile_account", is_flag=True)
 @network_option
 @mainnet_token_option
 @watch_option
@@ -171,6 +172,7 @@ async def declare(
     alias,
     overriding_path,
     token,
+    nile_account,
 ):
     """Declare a StarkNet smart contract through an Account."""
     account = await Account(signer, network)
@@ -181,6 +183,7 @@ async def declare(
         overriding_path=overriding_path,
         mainnet_token=token,
         watch_mode=watch_mode,
+        nile_account=nile_account,
     )
 
 

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -106,8 +106,7 @@ class Account(AsyncObject):
     async def deploy(self, salt=None, max_fee=None, query_type=None, watch_mode=None):
         """Deploy an Account contract for the given private key."""
         index = accounts.current_index(self.network)
-        pt = os.path.dirname(os.path.realpath(__file__)).replace("/core", "")
-        overriding_path = (f"{pt}/artifacts", f"{pt}/artifacts/abis")
+        overriding_path = set_nile_artifacts_path()
 
         class_hash = get_account_class_hash("Account")
         salt = 0 if salt is None else normalize_number(salt)
@@ -152,9 +151,14 @@ class Account(AsyncObject):
         overriding_path=None,
         mainnet_token=None,
         watch_mode=None,
+        nile_account=False,
     ):
         """Declare a contract through an Account."""
         max_fee, nonce, _ = await self._process_arguments(max_fee, nonce)
+
+        if nile_account:
+            assert overriding_path is None
+            overriding_path = set_nile_artifacts_path()
 
         contract_class = get_contract_class(
             contract_name=contract_name, overriding_path=overriding_path
@@ -174,6 +178,7 @@ class Account(AsyncObject):
             alias=alias,
             network=self.network,
             max_fee=max_fee,
+            overriding_path=overriding_path,
             mainnet_token=mainnet_token,
             watch_mode=watch_mode,
         )
@@ -187,6 +192,7 @@ class Account(AsyncObject):
         alias,
         max_fee=None,
         deployer_address=None,
+        overriding_path=None,
         abi=None,
         watch_mode=None,
     ):
@@ -204,6 +210,7 @@ class Account(AsyncObject):
             alias,
             deployer_address,
             max_fee,
+            overriding_path=overriding_path,
             abi=abi,
             watch_mode=watch_mode,
         )
@@ -294,3 +301,10 @@ def get_counterfactual_address(salt=None, calldata=None, contract="Account"):
         constructor_calldata=calldata,
         deployer_address=0,
     )
+
+
+def set_nile_artifacts_path():
+    """Set path to find Nile precompiled artifacts."""
+    pt = os.path.dirname(os.path.realpath(__file__)).replace("/core", "")
+    overriding_path = (f"{pt}/artifacts", f"{pt}/artifacts/abis")
+    return overriding_path

--- a/src/nile/core/account.py
+++ b/src/nile/core/account.py
@@ -304,7 +304,7 @@ def get_counterfactual_address(salt=None, calldata=None, contract="Account"):
 
 
 def set_nile_artifacts_path():
-    """Set path to find Nile precompiled artifacts."""
+    """Set path to find Nile's precompiled artifacts."""
     pt = os.path.dirname(os.path.realpath(__file__)).replace("/core", "")
     overriding_path = (f"{pt}/artifacts", f"{pt}/artifacts/abis")
     return overriding_path

--- a/src/nile/core/deploy.py
+++ b/src/nile/core/deploy.py
@@ -101,7 +101,7 @@ async def deploy_contract(
         _salt = compute_hash_chain(data=[account.address, salt])
         deployer_for_address_generation = deployer_address
 
-    class_hash = get_class_hash(contract_name=contract_name)
+    class_hash = get_class_hash(contract_name, overriding_path)
 
     address = calculate_contract_address_from_hash(
         _salt, class_hash, calldata, deployer_for_address_generation

--- a/tests/commands/test_account.py
+++ b/tests/commands/test_account.py
@@ -23,6 +23,7 @@ MAX_FEE = 10
 SALT = 444
 SIGNATURE = [111, 222]
 CLASS_HASH = 12345
+PATH = ("src/nile/artifacts", "src/nile/artifacts/abis")
 
 
 @pytest.fixture(autouse=True)
@@ -140,6 +141,7 @@ async def test_declare(mock_declare, mock_get_class, mock_hash, mock_deploy):
         network=NETWORK,
         alias=alias,
         max_fee=max_fee,
+        overriding_path=overriding_path,
         mainnet_token=None,
         watch_mode=None,
     )
@@ -149,11 +151,18 @@ async def test_declare(mock_declare, mock_get_class, mock_hash, mock_deploy):
 @pytest.mark.parametrize("deployer_address", [None, 0xDE0])
 @pytest.mark.parametrize("watch_mode", [None, "debug"])
 @pytest.mark.parametrize("abi", [None, "TEST_ABI"])
+@pytest.mark.parametrize("overriding_path", [None, PATH])
 @patch("nile.core.account.deploy_account", return_value=(MOCK_ADDRESS, MOCK_INDEX))
 @patch("nile.core.deploy.get_class_hash", return_value=0x434343)
 @patch("nile.core.account.deploy_with_deployer")
 async def test_deploy_contract(
-    mock_deploy_contract, mock_get_class, mock_deploy, abi, watch_mode, deployer_address
+    mock_deploy_contract,
+    mock_get_class,
+    mock_deploy,
+    overriding_path,
+    abi,
+    watch_mode,
+    deployer_address,
 ):
     account = await Account(KEY, NETWORK)
 
@@ -172,8 +181,9 @@ async def test_deploy_contract(
         alias,
         max_fee,
         deployer_address,
-        abi,
-        watch_mode,
+        overriding_path=overriding_path,
+        abi=abi,
+        watch_mode=watch_mode,
     )
 
     if deployer_address is None:
@@ -189,6 +199,7 @@ async def test_deploy_contract(
         alias,
         deployer_address,
         max_fee,
+        overriding_path=overriding_path,
         abi=abi,
         watch_mode=watch_mode,
     )

--- a/tests/commands/test_deploy.py
+++ b/tests/commands/test_deploy.py
@@ -19,16 +19,6 @@ def tmp_working_dir(monkeypatch, tmp_path):
     return tmp_path
 
 
-EXP_SALTS = [
-    2575391846029882800677169842619299590487820636126802982795520479739126412818,
-    2557841322555501036413859939246042028937187876697248667793106475357514195630,
-]
-EXP_CLASS_HASHES = [
-    0x434343,
-    0x464646,
-    0x494949,
-    0x525252,
-]
 MOCK_ACC_ADDRESS = 0x123
 MOCK_ACC_INDEX = 0
 CONTRACT = "contract"
@@ -46,6 +36,24 @@ CALL_OUTPUT = [ADDRESS, TX_HASH]
 SIGNATURE = [111, 333]
 SALT = 555
 FEE = 666
+
+DEPLOY_ARGS = [
+    # name, salt, unique, calldata, alias, deployer, max_fee, [overriding_path], [abi]
+    [CONTRACT, 0, True, [], ALIAS, 0x424242, 5],
+    [CONTRACT, 1, False, [1], ALIAS, 0x454545, 0],
+    [CONTRACT, 3, True, [1, 2], ALIAS, 0x484848, 0],
+    [CONTRACT, 3, False, [1, 2, 3], ALIAS, 0x515151, 0, None, ABI_OVERRIDE],
+]
+EXP_SALTS = [
+    2575391846029882800677169842619299590487820636126802982795520479739126412818,
+    2557841322555501036413859939246042028937187876697248667793106475357514195630,
+]
+EXP_CLASS_HASHES = [
+    0x434343,
+    0x464646,
+    0x494949,
+    0x525252,
+]
 
 
 @pytest.mark.asyncio
@@ -125,35 +133,25 @@ async def test_deploy(mock_register, mock_parse, caplog, args, cmd_args, exp_abi
     "args, exp_class_hash, exp_salt, exp_abi",
     [
         (
-            [CONTRACT, 0, True, [], ALIAS, 0x424242, 5],  # args
+            DEPLOY_ARGS[0],
             EXP_CLASS_HASHES[0],
             EXP_SALTS[0],
             ABI,
         ),
         (
-            [CONTRACT, 1, False, [1], ALIAS, 0x454545, 0],  # args
+            DEPLOY_ARGS[1],
             EXP_CLASS_HASHES[1],
             1,
             ABI,
         ),
         (
-            [CONTRACT, 3, True, [1, 2], ALIAS, 0x484848, 0],  # args
+            DEPLOY_ARGS[2],
             EXP_CLASS_HASHES[2],
             EXP_SALTS[1],
             ABI,
         ),
         (
-            [
-                CONTRACT,
-                3,
-                False,
-                [1, 2, 3],
-                ALIAS,
-                0x515151,
-                0,
-                None,
-                ABI_OVERRIDE,
-            ],  # args
+            DEPLOY_ARGS[3],
             EXP_CLASS_HASHES[3],
             3,
             ABI_OVERRIDE,
@@ -203,6 +201,7 @@ async def test_deploy_contract(
             max_fee=max_fee,
         )
         mock_register.assert_called_once_with(exp_address, exp_abi, NETWORK, ALIAS)
+        mock_return_account.assert_called_once_with(CONTRACT, None)
 
         # check logs
         assert f"🚀 Deploying {CONTRACT}" in caplog.text


### PR DESCRIPTION
This PR proposes to add the `nile-account` flag to `account.declare` which will create an overriding_path to Nile's precompiled artifacts. This will remove the need to manually set the path for Account declarations.

This PR just needs tests.

Resolves #309.