### PR TITLE
Proxy `nile node` unknown options to `starknet-devnet`

### DIFF
--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -12,6 +12,7 @@ from nile.core.call_or_invoke import call_or_invoke as call_or_invoke_command
 from nile.core.clean import clean as clean_command
 from nile.core.compile import compile as compile_command
 from nile.core.init import init as init_command
+from nile.core.node import get_help_message
 from nile.core.node import node as node_command
 from nile.core.plugins import load_plugins
 from nile.core.run import run as run_command
@@ -352,28 +353,27 @@ def clean(ctx):
     clean_command()
 
 
-@cli.command()
+class NodeCommand(click.Command):
+    """Command wrapper to override the default help message."""
+
+    def format_help(self, ctx, formatter):
+        """Help message override."""
+        click.echo(get_help_message())
+
+
+@cli.command(
+    context_settings=dict(
+        ignore_unknown_options=True,
+    ),
+    cls=NodeCommand,
+)
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=5050)
-@click.option("--seed", type=int)
-@click.option("--lite_mode", is_flag=True)
+@click.argument("node_args", nargs=-1, type=click.UNPROCESSED)
 @enable_stack_trace
-def node(ctx, host, port, seed, lite_mode):
-    """Start StarkNet local network.
-
-    $ nile node
-      Start StarkNet local network at port 5050
-
-    $ nile node --host HOST --port 5001
-      Start StarkNet network on address HOST listening at port 5001
-
-    $ nile node --seed SEED
-      Start StarkNet local network with seed SEED
-
-    $ nile node --lite_mode
-      Start StarkNet network on lite-mode
-    """
-    node_command(host, port, seed, lite_mode)
+def node(ctx, host, port, node_args):
+    """Start StarkNet local network."""
+    node_command(host, port, node_args)
 
 
 @cli.command()

--- a/src/nile/core/node.py
+++ b/src/nile/core/node.py
@@ -6,7 +6,7 @@ import subprocess
 from nile.common import DEFAULT_GATEWAYS, write_node_json
 
 
-def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
+def node(host="127.0.0.1", port=5050, node_args=None):
     """Start StarkNet local network."""
     try:
         # Save host and port information to be used by other commands
@@ -19,13 +19,8 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
             write_node_json(network, gateway_url)
 
         command = ["starknet-devnet", "--host", host, "--port", str(port)]
-
-        if seed is not None:
-            command.append("--seed")
-            command.append(str(seed))
-
-        if lite_mode:
-            command.append("--lite-mode")
+        if node_args is not None:
+            command += list(node_args)
 
         # Start network
         subprocess.check_call(command)
@@ -35,3 +30,21 @@ def node(host="127.0.0.1", port=5050, seed=None, lite_mode=False):
             "\n\n😰 Could not find starknet-devnet, is it installed? Try with:\n"
             "    pip install starknet-devnet"
         )
+
+
+def get_help_message():
+    """Retrieve and parse the help message from starknet-devnet."""
+    base = """
+Start StarkNet local network.
+
+$ nile node
+  Start StarkNet local network at port 5050
+
+Options:
+    """
+
+    raw_message = subprocess.check_output(["starknet-devnet", "--help"]).decode("utf-8")
+    options_index = raw_message.find("optional arguments:")
+    options = raw_message[options_index + 19 :]
+
+    return base + options

--- a/tests/commands/test_node.py
+++ b/tests/commands/test_node.py
@@ -5,12 +5,12 @@ from unittest.mock import patch
 
 import pytest
 
-from nile.core.node import node
+from nile.core.node import get_help_message, node
 
 HOST = "127.0.0.1"
 PORT = "5050"
 SEED = "123"
-LITE = "--lite-mode"
+HELP_OUTPUT = b"optional arguments:\n options"
 
 
 @pytest.fixture(autouse=True)
@@ -19,27 +19,42 @@ def tmp_working_dir(monkeypatch, tmp_path):
     return tmp_path
 
 
+@pytest.mark.parametrize("host", [HOST])
+@pytest.mark.parametrize("port", [PORT])
 @pytest.mark.parametrize(
-    "args",
+    "node_args",
     [
-        ({}),
-        ({"seed": SEED}),
-        ({"lite_mode": LITE}),
-        ({"host": HOST, "port": PORT}),
-        ({"host": HOST, "port": PORT, "seed": SEED, "lite_mode": LITE}),
+        None,
+        ("--seed", SEED),
+        ("--lite-mode"),
+        ("--fork-network", "alpha-mainnet"),
+        ("--fork-block", 4),
     ],
 )
 @patch("nile.core.node.subprocess.check_call")
-def test_node_call(mock_subprocess, args):
-    node(**args)
+def test_node_call(mock_subprocess, host, port, node_args):
+    node(host, port, node_args)
 
-    command = ["starknet-devnet", "--host", HOST, "--port", PORT]
-    if "seed" in args:
-        command.append("--seed")
-        command.append(SEED)
-    if "lite_mode" in args:
-        command.append(LITE)
+    command = ["starknet-devnet", "--host", host, "--port", port]
+    if node_args is not None:
+        command += list(node_args)
     mock_subprocess.assert_called_once_with(command)
+
+
+@patch("nile.core.node.subprocess.check_output", return_value=HELP_OUTPUT)
+def test_node_help_message(mock_subprocess):
+    base = """
+Start StarkNet local network.
+
+$ nile node
+  Start StarkNet local network at port 5050
+
+Options:
+    """
+
+    help_message = get_help_message()
+
+    assert help_message == base + "\n options"
 
 
 @patch("nile.core.node.subprocess.check_call")


### PR DESCRIPTION
Fixes #293 

This PR proposes to make available to the `nile node` interface all the options that `straknet-devnet` accepts by default.

This enables forking, but also the ability to specify the initial balances, the number of predeployed accounts, the gas price to be used, the account class to be used, etc...